### PR TITLE
Scaffold application structure and configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,56 @@
+# DataMiner Desktop Application Scaffold
+
+This repository provides the initial project structure for the DataMiner desktop
+application. The goal is to support fully offline execution, from document
+ingestion through retrieval and user interface rendering.
+
+## Prerequisites
+
+* Python 3.11 or later.
+* Ability to install Python packages from `requirements.txt` (the listed
+  dependencies are suitable for offline use once wheels are available locally).
+
+## Installation
+
+1. (Optional) Create and activate a virtual environment.
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate  # On Windows use `.venv\\Scripts\\activate`
+   ```
+2. Install dependencies in a single step.
+   ```bash
+   python -m pip install --upgrade pip
+   python -m pip install -r requirements.txt
+   ```
+
+## Launching the Application
+
+Run the PyQt6 interface via the package entry point:
+
+```bash
+python -m app
+```
+
+The starter UI displays a placeholder window confirming the application is
+running. Configuration files and logs are stored in the user-specific
+configuration directory (`%APPDATA%/DataMiner` on Windows or
+`~/.config/DataMiner` on Linux/macOS). All functionality operates locally; the
+application performs no network calls or telemetry by default.
+
+## Project Structure
+
+```
+app/
+├── __init__.py
+├── __main__.py
+├── config.py
+├── logging.py
+├── ingest/
+├── retrieval/
+├── services/
+├── storage/
+└── ui/
+```
+
+Each subpackage is prepared for future expansion to cover document ingestion,
+storage, retrieval, background services, and the PyQt6 user interface.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,4 @@
+"""Top-level package for the DataMiner desktop application."""
+
+from .config import ConfigManager, get_user_config_dir  # noqa: F401
+from .logging import setup_logging  # noqa: F401

--- a/app/__main__.py
+++ b/app/__main__.py
@@ -1,0 +1,30 @@
+"""Entry point for launching the DataMiner desktop application."""
+
+from __future__ import annotations
+
+import sys
+
+from PyQt6.QtWidgets import QApplication, QLabel
+
+from .logging import setup_logging
+
+
+def main() -> None:
+    """Start the PyQt6 application."""
+    logger = setup_logging()
+    logger.debug("Starting QApplication")
+
+    app = QApplication(sys.argv)
+    app.setApplicationName("DataMiner")
+
+    window = QLabel("DataMiner is running.")
+    window.setWindowTitle("DataMiner")
+    window.resize(400, 200)
+    window.show()
+
+    logger.info("Application started")
+    sys.exit(app.exec())
+
+
+if __name__ == "__main__":
+    main()

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,110 @@
+"""Application configuration management."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from configparser import ConfigParser
+from pathlib import Path
+from typing import Any, MutableMapping
+
+CONFIG_DIR_NAME = "DataMiner"
+DEFAULT_JSON_FILENAME = "settings.json"
+DEFAULT_INI_FILENAME = "settings.ini"
+
+
+def get_user_config_dir(app_name: str = CONFIG_DIR_NAME) -> Path:
+    """Return the configuration directory for the current user.
+
+    The directory is created on first use. On Windows the directory is
+    under ``%APPDATA%``; otherwise the XDG base directory or ``~/.config``
+    is used.
+    """
+    if sys.platform.startswith("win"):
+        base_dir = Path(os.getenv("APPDATA", Path.home()))
+    else:
+        base_dir = Path(os.getenv("XDG_CONFIG_HOME", Path.home() / ".config"))
+    config_dir = base_dir / app_name
+    config_dir.mkdir(parents=True, exist_ok=True)
+    return config_dir
+
+
+class ConfigManager:
+    """Handle loading and saving user configuration settings."""
+
+    def __init__(
+        self,
+        app_name: str = CONFIG_DIR_NAME,
+        *,
+        format: str = "json",
+        filename: str | None = None,
+    ) -> None:
+        self.app_name = app_name
+        self.format = format.lower()
+        if self.format not in {"json", "ini"}:
+            raise ValueError("format must be either 'json' or 'ini'")
+        if filename is None:
+            filename = (
+                DEFAULT_JSON_FILENAME if self.format == "json" else DEFAULT_INI_FILENAME
+            )
+        self.config_dir = get_user_config_dir(app_name)
+        self.config_path = self.config_dir / filename
+
+    def load(self) -> dict[str, Any]:
+        """Load configuration from disk.
+
+        Returns an empty dictionary if the configuration file is absent.
+        """
+        if not self.config_path.exists():
+            return {}
+
+        if self.format == "json":
+            with self.config_path.open("r", encoding="utf-8") as fh:
+                return json.load(fh)
+
+        parser = ConfigParser()
+        parser.read(self.config_path, encoding="utf-8")
+        return {section: dict(parser.items(section)) for section in parser.sections()}
+
+    def save(self, data: MutableMapping[str, Any]) -> None:
+        """Persist configuration data to disk."""
+        if self.format == "json":
+            with self.config_path.open("w", encoding="utf-8") as fh:
+                json.dump(data, fh, indent=2, sort_keys=True)
+                fh.write("\n")
+            return
+
+        parser = ConfigParser()
+        for section, values in data.items():
+            if not isinstance(values, MutableMapping):
+                raise ValueError("INI configuration requires mapping values per section")
+            parser[section] = {str(key): str(value) for key, value in values.items()}
+        with self.config_path.open("w", encoding="utf-8") as fh:
+            parser.write(fh)
+
+    def update(self, data: MutableMapping[str, Any]) -> dict[str, Any]:
+        """Update the stored configuration with ``data`` and return the result."""
+        current = self.load()
+        if self.format == "json":
+            current.update(data)
+        else:
+            for section, values in data.items():
+                if not isinstance(values, MutableMapping):
+                    raise ValueError(
+                        "INI configuration updates require mapping values per section"
+                    )
+                section_data = current.setdefault(section, {})
+                if not isinstance(section_data, dict):
+                    raise ValueError(
+                        "Existing INI section must be a mapping to apply updates"
+                    )
+                section_data.update(values)
+        self.save(current)
+        return current
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging helper
+        return f"ConfigManager(app_name={self.app_name!r}, format={self.format!r}, path={self.config_path!s})"
+
+
+__all__ = ["ConfigManager", "get_user_config_dir"]

--- a/app/ingest/__init__.py
+++ b/app/ingest/__init__.py
@@ -1,0 +1,3 @@
+"""Document ingestion utilities for the DataMiner application."""
+
+__all__: list[str] = []

--- a/app/logging.py
+++ b/app/logging.py
@@ -1,0 +1,59 @@
+"""Logging utilities for the DataMiner application."""
+
+from __future__ import annotations
+
+import logging
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+from typing import Optional
+
+from .config import get_user_config_dir
+
+LOG_FILENAME = "dataminer.log"
+MAX_BYTES = 1_048_576  # 1 MiB
+BACKUP_COUNT = 3
+
+
+def setup_logging(
+    app_name: str = "DataMiner",
+    *,
+    level: int = logging.INFO,
+    log_filename: Optional[str] = None,
+) -> logging.Logger:
+    """Configure logging for the application and return the root logger.
+
+    Logging output is directed to both the console and a rotating file located
+    in the user's configuration directory. This utility avoids any external
+    telemetry by keeping all logs on the local filesystem.
+    """
+    logger = logging.getLogger(app_name)
+    if logger.handlers:
+        return logger
+
+    logger.setLevel(level)
+    formatter = logging.Formatter(
+        "%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
+    config_dir = get_user_config_dir(app_name)
+    log_path = Path(config_dir) / (log_filename or LOG_FILENAME)
+
+    file_handler = RotatingFileHandler(
+        log_path,
+        maxBytes=MAX_BYTES,
+        backupCount=BACKUP_COUNT,
+        encoding="utf-8",
+    )
+    file_handler.setFormatter(formatter)
+    logger.addHandler(file_handler)
+
+    console_handler = logging.StreamHandler()
+    console_handler.setFormatter(formatter)
+    logger.addHandler(console_handler)
+
+    logger.debug("Logging initialised. Writing to %s", log_path)
+    return logger
+
+
+__all__ = ["setup_logging"]

--- a/app/retrieval/__init__.py
+++ b/app/retrieval/__init__.py
@@ -1,0 +1,3 @@
+"""Information retrieval components for the DataMiner application."""
+
+__all__: list[str] = []

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,0 +1,3 @@
+"""Background services for the DataMiner application."""
+
+__all__: list[str] = []

--- a/app/storage/__init__.py
+++ b/app/storage/__init__.py
@@ -1,0 +1,3 @@
+"""Storage interfaces for the DataMiner application."""
+
+__all__: list[str] = []

--- a/app/ui/__init__.py
+++ b/app/ui/__init__.py
@@ -1,0 +1,3 @@
+"""UI components for the DataMiner application."""
+
+__all__: list[str] = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+PyQt6
+PyMuPDF
+python-docx
+markdown
+chardet
+numpy
+scikit-learn
+rank-bm25


### PR DESCRIPTION
## Summary
- add a requirements.txt with PyQt6, document parsing, and offline retrieval dependencies
- scaffold the app package with UI, ingestion, storage, retrieval, and services subpackages and a PyQt6 entry point
- implement configuration and logging utilities that store data under the user profile and document setup/launch steps in the README

## Testing
- `python -m compileall app`


------
https://chatgpt.com/codex/tasks/task_e_68d3290e51208322ab50e30233a70e4e