### PR TITLE
Add SQLite schema management and repository layer

### DIFF
--- a/app/storage/__init__.py
+++ b/app/storage/__init__.py
@@ -1,3 +1,19 @@
 """Storage interfaces for the DataMiner application."""
 
-__all__: list[str] = []
+from .database import (
+    BaseRepository,
+    ChatRepository,
+    DatabaseError,
+    DatabaseManager,
+    DocumentRepository,
+    ProjectRepository,
+)
+
+__all__ = [
+    "BaseRepository",
+    "ChatRepository",
+    "DatabaseError",
+    "DatabaseManager",
+    "DocumentRepository",
+    "ProjectRepository",
+]

--- a/app/storage/database.py
+++ b/app/storage/database.py
@@ -1,0 +1,413 @@
+"""Database utilities and migration helpers for the storage layer."""
+
+from __future__ import annotations
+
+import contextlib
+import datetime as _dt
+import shutil
+import sqlite3
+from pathlib import Path
+from typing import Any, Callable, Iterable
+
+SCHEMA_VERSION = 1
+SCHEMA_FILENAME = "schema.sql"
+
+
+class DatabaseError(RuntimeError):
+    """Raised when database bootstrap or migrations fail."""
+
+
+class DatabaseManager:
+    """Manage the SQLite database connection and schema migrations."""
+
+    def __init__(self, path: str | Path) -> None:
+        self.path = Path(path)
+        if not self.path.parent.exists():
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._connection: sqlite3.Connection | None = None
+
+    def connect(self) -> sqlite3.Connection:
+        """Return a singleton SQLite connection with sensible defaults."""
+        if self._connection is None:
+            connection = sqlite3.connect(self.path)
+            connection.row_factory = sqlite3.Row
+            connection.execute("PRAGMA foreign_keys = ON")
+            self._connection = connection
+        return self._connection
+
+    def close(self) -> None:
+        """Close the underlying database connection if it exists."""
+        if self._connection is not None:
+            self._connection.close()
+            self._connection = None
+
+    def initialize(self) -> None:
+        """Bootstrap the database schema, applying migrations if required."""
+        connection = self.connect()
+        try:
+            with connection:  # Start a transaction so initialization is atomic.
+                version = self._get_user_version(connection)
+                if version > SCHEMA_VERSION:
+                    raise DatabaseError(
+                        "Database schema version is newer than this application supports"
+                    )
+                if version == 0:
+                    self._install_base_schema(connection)
+                elif version < SCHEMA_VERSION:
+                    self._apply_migrations(connection, version)
+        except sqlite3.DatabaseError as exc:  # pragma: no cover - defensive
+            raise DatabaseError(str(exc)) from exc
+
+    def _install_base_schema(self, connection: sqlite3.Connection) -> None:
+        schema_path = Path(__file__).with_name(SCHEMA_FILENAME)
+        schema_sql = schema_path.read_text(encoding="utf-8")
+        connection.executescript(schema_sql)
+        self._set_user_version(connection, SCHEMA_VERSION)
+
+    def _apply_migrations(self, connection: sqlite3.Connection, current: int) -> None:
+        """Placeholder for future migrations from ``current`` to ``SCHEMA_VERSION``."""
+        if current >= SCHEMA_VERSION:
+            return
+        # No incremental migrations yet; reapply schema to fill gaps.
+        self._install_base_schema(connection)
+
+    @staticmethod
+    def _get_user_version(connection: sqlite3.Connection) -> int:
+        cursor = connection.execute("PRAGMA user_version")
+        row = cursor.fetchone()
+        return int(row[0]) if row else 0
+
+    @staticmethod
+    def _set_user_version(connection: sqlite3.Connection, version: int) -> None:
+        connection.execute(f"PRAGMA user_version = {version}")
+
+    @contextlib.contextmanager
+    def transaction(self) -> Iterable[sqlite3.Connection]:
+        """Context manager that wraps operations in a transaction."""
+        connection = self.connect()
+        try:
+            with connection:
+                yield connection
+        except sqlite3.DatabaseError as exc:  # pragma: no cover - defensive
+            raise DatabaseError(str(exc)) from exc
+
+    def export_database(self, destination: str | Path) -> Path:
+        """Create a consistent snapshot of the database at ``destination``."""
+        destination_path = Path(destination)
+        if destination_path.is_dir():
+            timestamp = _dt.datetime.utcnow().strftime("%Y%m%d%H%M%S")
+            destination_path = destination_path / f"{self.path.stem}-backup-{timestamp}.db"
+        if not destination_path.parent.exists():
+            destination_path.parent.mkdir(parents=True, exist_ok=True)
+        connection = self.connect()
+        with sqlite3.connect(destination_path) as backup_conn:
+            connection.backup(backup_conn)
+        return destination_path
+
+    def import_database(self, source: str | Path) -> Path:
+        """Replace the current database with ``source`` ensuring schema compatibility."""
+        source_path = Path(source)
+        if not source_path.exists():
+            raise FileNotFoundError(source_path)
+        self.close()
+        staging_path = self.path.with_suffix(".staging")
+        shutil.copy2(source_path, staging_path)
+        with sqlite3.connect(staging_path) as staging_conn:
+            version = self._get_user_version(staging_conn)
+            if version > SCHEMA_VERSION:
+                raise DatabaseError(
+                    "Imported database has a newer schema version than supported"
+                )
+        staging_path.replace(self.path)
+        self.initialize()
+        return self.path
+
+
+class BaseRepository:
+    """Common utilities shared by repository implementations."""
+
+    def __init__(self, db: DatabaseManager) -> None:
+        self.db = db
+
+    @contextlib.contextmanager
+    def transaction(self) -> Iterable[sqlite3.Connection]:
+        with self.db.transaction() as connection:
+            yield connection
+
+    @staticmethod
+    def _row_to_dict(row: sqlite3.Row | None) -> dict[str, Any] | None:
+        if row is None:
+            return None
+        return {key: row[key] for key in row.keys()}
+
+
+class ProjectRepository(BaseRepository):
+    """CRUD helpers for project rows."""
+
+    def create(self, name: str, description: str | None = None) -> dict[str, Any]:
+        with self.transaction() as connection:
+            cursor = connection.execute(
+                "INSERT INTO projects (name, description) VALUES (?, ?)",
+                (name, description),
+            )
+            project_id = cursor.lastrowid
+            return self.get(project_id)  # type: ignore[return-value]
+
+    def get(self, project_id: int) -> dict[str, Any] | None:
+        connection = self.db.connect()
+        row = connection.execute(
+            "SELECT * FROM projects WHERE id = ?", (project_id,)
+        ).fetchone()
+        return self._row_to_dict(row)
+
+    def list(self) -> list[dict[str, Any]]:
+        connection = self.db.connect()
+        rows = connection.execute(
+            "SELECT * FROM projects ORDER BY created_at ASC"
+        ).fetchall()
+        return [self._row_to_dict(row) for row in rows if row is not None]  # type: ignore[list-item]
+
+    def update(self, project_id: int, **fields: Any) -> dict[str, Any] | None:
+        if not fields:
+            return self.get(project_id)
+        columns = ", ".join(f"{key} = ?" for key in fields.keys())
+        values = list(fields.values()) + [project_id]
+        with self.transaction() as connection:
+            connection.execute(f"UPDATE projects SET {columns} WHERE id = ?", values)
+        return self.get(project_id)
+
+    def delete(self, project_id: int) -> None:
+        with self.transaction() as connection:
+            connection.execute("DELETE FROM projects WHERE id = ?", (project_id,))
+
+
+class DocumentRepository(BaseRepository):
+    """Manage documents, file versions, tags, and embeddings."""
+
+    def create(
+        self,
+        project_id: int,
+        title: str,
+        *,
+        source_type: str | None = None,
+        source_path: str | Path | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        metadata_json = None
+        if metadata is not None:
+            import json
+
+            metadata_json = json.dumps(metadata)
+        stored_path = str(source_path) if source_path is not None else None
+        with self.transaction() as connection:
+            cursor = connection.execute(
+                """
+                INSERT INTO documents (project_id, title, source_type, source_path, metadata)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (project_id, title, source_type, stored_path, metadata_json),
+            )
+            document_id = cursor.lastrowid
+        return self.get(document_id)  # type: ignore[return-value]
+
+    def get(self, document_id: int) -> dict[str, Any] | None:
+        row = self.db.connect().execute(
+            "SELECT * FROM documents WHERE id = ?", (document_id,)
+        ).fetchone()
+        data = self._row_to_dict(row)
+        if data and data.get("metadata"):
+            import json
+
+            data["metadata"] = json.loads(data["metadata"])
+        return data
+
+    def list_for_project(self, project_id: int) -> list[dict[str, Any]]:
+        rows = self.db.connect().execute(
+            "SELECT * FROM documents WHERE project_id = ? ORDER BY created_at ASC",
+            (project_id,),
+        ).fetchall()
+        documents: list[dict[str, Any]] = []
+        for row in rows:
+            document = self._row_to_dict(row)
+            if document and document.get("metadata"):
+                import json
+
+                document["metadata"] = json.loads(document["metadata"])
+            if document:
+                documents.append(document)
+        return documents
+
+    def delete(self, document_id: int) -> None:
+        with self.transaction() as connection:
+            connection.execute("DELETE FROM documents WHERE id = ?", (document_id,))
+
+    def add_file_version(
+        self,
+        document_id: int,
+        *,
+        file_path: str | Path,
+        checksum: str | None = None,
+        file_size: int | None = None,
+    ) -> dict[str, Any]:
+        connection = self.db.connect()
+        row = connection.execute(
+            "SELECT COALESCE(MAX(version), 0) + 1 FROM file_versions WHERE document_id = ?",
+            (document_id,),
+        ).fetchone()
+        version = int(row[0]) if row else 1
+        with self.transaction() as tx:
+            cursor = tx.execute(
+                """
+                INSERT INTO file_versions (document_id, version, file_path, checksum, file_size)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (document_id, version, str(file_path), checksum, file_size),
+            )
+            version_id = cursor.lastrowid
+        return self.get_file_version(version_id)  # type: ignore[return-value]
+
+    def get_file_version(self, version_id: int) -> dict[str, Any] | None:
+        row = self.db.connect().execute(
+            "SELECT * FROM file_versions WHERE id = ?", (version_id,)
+        ).fetchone()
+        return self._row_to_dict(row)
+
+    def list_file_versions(self, document_id: int) -> list[dict[str, Any]]:
+        rows = self.db.connect().execute(
+            "SELECT * FROM file_versions WHERE document_id = ? ORDER BY version ASC",
+            (document_id,),
+        ).fetchall()
+        return [self._row_to_dict(row) for row in rows if row is not None]  # type: ignore[list-item]
+
+    def create_tag(
+        self, project_id: int, name: str, description: str | None = None, color: str | None = None
+    ) -> dict[str, Any]:
+        with self.transaction() as connection:
+            cursor = connection.execute(
+                "INSERT INTO tags (project_id, name, description, color) VALUES (?, ?, ?, ?)",
+                (project_id, name, description, color),
+            )
+            tag_id = cursor.lastrowid
+        return self.get_tag(tag_id)  # type: ignore[return-value]
+
+    def get_tag(self, tag_id: int) -> dict[str, Any] | None:
+        row = self.db.connect().execute(
+            "SELECT * FROM tags WHERE id = ?", (tag_id,)
+        ).fetchone()
+        return self._row_to_dict(row)
+
+    def tag_document(self, document_id: int, tag_id: int) -> None:
+        with self.transaction() as connection:
+            connection.execute(
+                "INSERT OR IGNORE INTO tag_links (tag_id, document_id) VALUES (?, ?)",
+                (tag_id, document_id),
+            )
+
+    def list_tags_for_document(self, document_id: int) -> list[dict[str, Any]]:
+        rows = self.db.connect().execute(
+            """
+            SELECT tags.*
+            FROM tags
+            INNER JOIN tag_links ON tag_links.tag_id = tags.id
+            WHERE tag_links.document_id = ?
+            ORDER BY tags.name ASC
+            """,
+            (document_id,),
+        ).fetchall()
+        return [self._row_to_dict(row) for row in rows if row is not None]  # type: ignore[list-item]
+
+
+class ChatRepository(BaseRepository):
+    """Manage chat sessions, citations, and reasoning summaries."""
+
+    def create(self, project_id: int, title: str | None = None) -> dict[str, Any]:
+        with self.transaction() as connection:
+            cursor = connection.execute(
+                "INSERT INTO chats (project_id, title) VALUES (?, ?)",
+                (project_id, title),
+            )
+            chat_id = cursor.lastrowid
+        return self.get(chat_id)  # type: ignore[return-value]
+
+    def get(self, chat_id: int) -> dict[str, Any] | None:
+        row = self.db.connect().execute(
+            "SELECT * FROM chats WHERE id = ?", (chat_id,)
+        ).fetchone()
+        return self._row_to_dict(row)
+
+    def list_for_project(self, project_id: int) -> list[dict[str, Any]]:
+        rows = self.db.connect().execute(
+            "SELECT * FROM chats WHERE project_id = ? ORDER BY created_at ASC",
+            (project_id,),
+        ).fetchall()
+        return [self._row_to_dict(row) for row in rows if row is not None]  # type: ignore[list-item]
+
+    def delete(self, chat_id: int) -> None:
+        with self.transaction() as connection:
+            connection.execute("DELETE FROM chats WHERE id = ?", (chat_id,))
+
+    def add_citation(
+        self,
+        chat_id: int,
+        *,
+        document_id: int | None = None,
+        file_version_id: int | None = None,
+        snippet: str | None = None,
+    ) -> dict[str, Any]:
+        with self.transaction() as connection:
+            cursor = connection.execute(
+                """
+                INSERT INTO citations (chat_id, document_id, file_version_id, snippet)
+                VALUES (?, ?, ?, ?)
+                """,
+                (chat_id, document_id, file_version_id, snippet),
+            )
+            citation_id = cursor.lastrowid
+        return self.get_citation(citation_id)  # type: ignore[return-value]
+
+    def get_citation(self, citation_id: int) -> dict[str, Any] | None:
+        row = self.db.connect().execute(
+            "SELECT * FROM citations WHERE id = ?",
+            (citation_id,),
+        ).fetchone()
+        return self._row_to_dict(row)
+
+    def list_citations(self, chat_id: int) -> list[dict[str, Any]]:
+        rows = self.db.connect().execute(
+            "SELECT * FROM citations WHERE chat_id = ? ORDER BY created_at ASC",
+            (chat_id,),
+        ).fetchall()
+        return [self._row_to_dict(row) for row in rows if row is not None]  # type: ignore[list-item]
+
+    def add_reasoning_summary(self, chat_id: int, content: str) -> dict[str, Any]:
+        with self.transaction() as connection:
+            cursor = connection.execute(
+                "INSERT INTO reasoning_summaries (chat_id, content) VALUES (?, ?)",
+                (chat_id, content),
+            )
+            summary_id = cursor.lastrowid
+        return self.get_reasoning_summary(summary_id)  # type: ignore[return-value]
+
+    def get_reasoning_summary(self, summary_id: int) -> dict[str, Any] | None:
+        row = self.db.connect().execute(
+            "SELECT * FROM reasoning_summaries WHERE id = ?",
+            (summary_id,),
+        ).fetchone()
+        return self._row_to_dict(row)
+
+    def list_reasoning_summaries(self, chat_id: int) -> list[dict[str, Any]]:
+        rows = self.db.connect().execute(
+            "SELECT * FROM reasoning_summaries WHERE chat_id = ? ORDER BY created_at ASC",
+            (chat_id,),
+        ).fetchall()
+        return [self._row_to_dict(row) for row in rows if row is not None]  # type: ignore[list-item]
+
+
+__all__ = [
+    "DatabaseError",
+    "DatabaseManager",
+    "BaseRepository",
+    "ProjectRepository",
+    "DocumentRepository",
+    "ChatRepository",
+]

--- a/app/storage/schema.sql
+++ b/app/storage/schema.sql
@@ -1,0 +1,144 @@
+PRAGMA journal_mode = WAL;
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS projects (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    description TEXT,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TRIGGER IF NOT EXISTS projects_set_updated_at
+AFTER UPDATE ON projects
+FOR EACH ROW
+BEGIN
+    UPDATE projects SET updated_at = CURRENT_TIMESTAMP WHERE id = OLD.id;
+END;
+
+CREATE TABLE IF NOT EXISTS documents (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    project_id INTEGER NOT NULL,
+    title TEXT NOT NULL,
+    source_type TEXT,
+    source_path TEXT,
+    metadata TEXT,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE
+);
+
+CREATE TRIGGER IF NOT EXISTS documents_set_updated_at
+AFTER UPDATE ON documents
+FOR EACH ROW
+BEGIN
+    UPDATE documents SET updated_at = CURRENT_TIMESTAMP WHERE id = OLD.id;
+END;
+
+CREATE TABLE IF NOT EXISTS file_versions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    document_id INTEGER NOT NULL,
+    version INTEGER NOT NULL,
+    file_path TEXT NOT NULL,
+    checksum TEXT,
+    file_size INTEGER,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(document_id, version),
+    FOREIGN KEY (document_id) REFERENCES documents(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS tags (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    project_id INTEGER NOT NULL,
+    name TEXT NOT NULL,
+    description TEXT,
+    color TEXT,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(project_id, name),
+    FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS tag_links (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    tag_id INTEGER NOT NULL,
+    document_id INTEGER NOT NULL,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(tag_id, document_id),
+    FOREIGN KEY (tag_id) REFERENCES tags(id) ON DELETE CASCADE,
+    FOREIGN KEY (document_id) REFERENCES documents(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS embeddings (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    document_id INTEGER NOT NULL,
+    file_version_id INTEGER,
+    embedding_type TEXT NOT NULL,
+    dimensions INTEGER NOT NULL,
+    vector BLOB NOT NULL,
+    metadata TEXT,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (document_id) REFERENCES documents(id) ON DELETE CASCADE,
+    FOREIGN KEY (file_version_id) REFERENCES file_versions(id) ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_embeddings_document_id ON embeddings(document_id);
+CREATE INDEX IF NOT EXISTS idx_embeddings_type ON embeddings(embedding_type);
+
+CREATE TABLE IF NOT EXISTS chats (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    project_id INTEGER NOT NULL,
+    title TEXT,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE
+);
+
+CREATE TRIGGER IF NOT EXISTS chats_set_updated_at
+AFTER UPDATE ON chats
+FOR EACH ROW
+BEGIN
+    UPDATE chats SET updated_at = CURRENT_TIMESTAMP WHERE id = OLD.id;
+END;
+
+CREATE TABLE IF NOT EXISTS citations (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    chat_id INTEGER NOT NULL,
+    document_id INTEGER,
+    file_version_id INTEGER,
+    snippet TEXT,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (chat_id) REFERENCES chats(id) ON DELETE CASCADE,
+    FOREIGN KEY (document_id) REFERENCES documents(id) ON DELETE SET NULL,
+    FOREIGN KEY (file_version_id) REFERENCES file_versions(id) ON DELETE SET NULL
+);
+
+CREATE TABLE IF NOT EXISTS reasoning_summaries (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    chat_id INTEGER NOT NULL,
+    content TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (chat_id) REFERENCES chats(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS settings (
+    key TEXT PRIMARY KEY,
+    value TEXT,
+    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TRIGGER IF NOT EXISTS settings_set_updated_at
+AFTER UPDATE ON settings
+FOR EACH ROW
+BEGIN
+    UPDATE settings SET updated_at = CURRENT_TIMESTAMP WHERE key = OLD.key;
+END;
+
+CREATE TABLE IF NOT EXISTS background_task_logs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_name TEXT NOT NULL,
+    status TEXT NOT NULL,
+    message TEXT,
+    extra_data TEXT,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    completed_at TEXT
+);

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.storage import ChatRepository, DatabaseManager, DocumentRepository, ProjectRepository
+
+
+@pytest.fixture()
+def database(tmp_path: Path) -> DatabaseManager:
+    db_path = tmp_path / "dataminer.db"
+    manager = DatabaseManager(db_path)
+    manager.initialize()
+    yield manager
+    manager.close()
+
+
+@pytest.fixture()
+def project_repo(database: DatabaseManager) -> ProjectRepository:
+    return ProjectRepository(database)
+
+
+@pytest.fixture()
+def document_repo(database: DatabaseManager) -> DocumentRepository:
+    return DocumentRepository(database)
+
+
+@pytest.fixture()
+def chat_repo(database: DatabaseManager) -> ChatRepository:
+    return ChatRepository(database)
+
+
+def test_project_crud(project_repo: ProjectRepository) -> None:
+    project = project_repo.create("Project Alpha", description="Primary")
+    assert project["name"] == "Project Alpha"
+
+    fetched = project_repo.get(project["id"])
+    assert fetched == project
+
+    updated = project_repo.update(project["id"], name="Renamed")
+    assert updated["name"] == "Renamed"
+
+    all_projects = project_repo.list()
+    assert len(all_projects) == 1
+
+    project_repo.delete(project["id"])
+    assert project_repo.get(project["id"]) is None
+
+
+def test_document_crud_and_cascade(
+    tmp_path: Path,
+    project_repo: ProjectRepository,
+    document_repo: DocumentRepository,
+    chat_repo: ChatRepository,
+) -> None:
+    project = project_repo.create("Project Beta")
+    document = document_repo.create(
+        project["id"],
+        "Spec Sheet",
+        source_type="file",
+        source_path=tmp_path / "spec.pdf",
+        metadata={"pages": 12},
+    )
+    assert document["metadata"] == {"pages": 12}
+
+    file_path = tmp_path / "spec.pdf"
+    file_path.write_text("dummy data")
+    version = document_repo.add_file_version(
+        document["id"],
+        file_path=file_path,
+        checksum="abc123",
+        file_size=file_path.stat().st_size,
+    )
+    assert version["version"] == 1
+
+    tag = document_repo.create_tag(project["id"], "urgent")
+    document_repo.tag_document(document["id"], tag["id"])
+    tags = document_repo.list_tags_for_document(document["id"])
+    assert tags[0]["name"] == "urgent"
+
+    chat = chat_repo.create(project["id"], "Review")
+    citation = chat_repo.add_citation(chat["id"], document_id=document["id"], snippet="See section 2")
+    assert citation["document_id"] == document["id"]
+    summary = chat_repo.add_reasoning_summary(chat["id"], "Relevant to requirements")
+    assert "Relevant" in summary["content"]
+
+    # deleting the project should cascade to documents, versions, chats, etc.
+    project_repo.delete(project["id"])
+    assert document_repo.get(document["id"]) is None
+    assert document_repo.get_file_version(version["id"]) is None
+    assert chat_repo.get(chat["id"]) is None
+    assert chat_repo.get_citation(citation["id"]) is None
+    assert chat_repo.get_reasoning_summary(summary["id"]) is None
+
+    # ensure the backing file remains untouched
+    assert file_path.exists()
+
+
+def test_project_isolation(
+    project_repo: ProjectRepository, document_repo: DocumentRepository
+) -> None:
+    project_a = project_repo.create("Project A")
+    project_b = project_repo.create("Project B")
+
+    doc_a = document_repo.create(project_a["id"], "Doc A")
+    doc_b = document_repo.create(project_b["id"], "Doc B")
+
+    docs_for_a = document_repo.list_for_project(project_a["id"])
+    docs_for_b = document_repo.list_for_project(project_b["id"])
+
+    assert {doc["id"] for doc in docs_for_a} == {doc_a["id"]}
+    assert {doc["id"] for doc in docs_for_b} == {doc_b["id"]}
+
+    # deleting one project should not remove the other project's data
+    project_repo.delete(project_a["id"])
+    assert document_repo.get(doc_b["id"]) is not None


### PR DESCRIPTION
## Summary
- define the SQLite schema for projects, documents, tags, embeddings, chats, settings, and background tasks
- add a database manager with bootstrap, migration placeholders, and backup/restore helpers plus repository classes
- cover CRUD flows, cascading deletes, and project isolation with unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d34b3798048322b50e61a6e2de3fa5