### PR TITLE
Add document parsing pipeline and preview service

### DIFF
--- a/app/ingest/parsers/__init__.py
+++ b/app/ingest/parsers/__init__.py
@@ -1,0 +1,108 @@
+"""Document parsers that extract text and structural metadata."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, asdict, field
+from pathlib import Path
+from typing import Any, Callable, Iterable
+
+
+@dataclass(slots=True)
+class PageContent:
+    """Representation of a single logical page."""
+
+    number: int
+    text: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class DocumentSection:
+    """Hierarchical section extracted from a document."""
+
+    title: str | None
+    content: str
+    level: int | None = None
+    page_number: int | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class ParsedDocument:
+    """Normalized representation returned by document parsers."""
+
+    text: str
+    metadata: dict[str, Any]
+    sections: list[DocumentSection] = field(default_factory=list)
+    pages: list[PageContent] = field(default_factory=list)
+    needs_ocr: bool = False
+    ocr_hint: str | None = None
+
+    def to_json(self) -> str:
+        """Return a JSON representation of structured data for storage."""
+
+        payload = {
+            "metadata": self.metadata,
+            "sections": [section.to_dict() for section in self.sections],
+            "pages": [page.to_dict() for page in self.pages],
+            "needs_ocr": self.needs_ocr,
+            "ocr_hint": self.ocr_hint,
+        }
+        return json.dumps(payload)
+
+
+class ParserError(RuntimeError):
+    """Raised when a parser cannot handle the supplied document."""
+from .docx_parser import parse_docx
+from .markdown_parser import parse_markdown
+from .pdf_parser import parse_pdf
+from .text_parser import parse_text
+
+
+Parser = Callable[[Path], ParsedDocument]
+
+
+_PARSERS: dict[str, Parser] = {
+    ".pdf": parse_pdf,
+    ".docx": parse_docx,
+    ".txt": parse_text,
+    ".text": parse_text,
+    ".md": parse_markdown,
+    ".markdown": parse_markdown,
+    ".mkd": parse_markdown,
+}
+
+
+def register_parser(suffixes: Iterable[str], parser: Parser) -> None:
+    """Register ``parser`` for the provided ``suffixes``."""
+
+    for suffix in suffixes:
+        _PARSERS[suffix.lower()] = parser
+
+
+def parse_file(path: str | Path) -> ParsedDocument:
+    """Parse ``path`` and return a :class:`ParsedDocument` instance."""
+
+    resolved = Path(path).resolve()
+    if not resolved.exists():
+        raise ParserError(f"Missing document: {resolved}")
+    suffix = resolved.suffix.lower()
+    parser = _PARSERS.get(suffix)
+    if parser is None:
+        raise ParserError(f"Unsupported file type: {resolved.suffix}")
+    return parser(resolved)
+
+
+__all__ = [
+    "DocumentSection",
+    "PageContent",
+    "ParsedDocument",
+    "ParserError",
+    "parse_file",
+    "register_parser",
+]

--- a/app/ingest/parsers/docx_parser.py
+++ b/app/ingest/parsers/docx_parser.py
@@ -1,0 +1,78 @@
+"""DOCX parser that extracts text, headings, and metadata."""
+
+from __future__ import annotations
+
+import datetime as _dt
+from pathlib import Path
+from typing import Any
+
+from . import DocumentSection, PageContent, ParsedDocument, ParserError
+
+
+def _extract_core_properties(doc: Any) -> dict[str, Any]:
+    properties = doc.core_properties
+    metadata: dict[str, Any] = {}
+    for attr in (
+        "title",
+        "subject",
+        "author",
+        "category",
+        "comments",
+        "keywords",
+        "last_modified_by",
+    ):
+        value = getattr(properties, attr, None)
+        if value:
+            metadata[attr] = value
+
+    for attr in ("created", "modified", "last_printed"):
+        value = getattr(properties, attr, None)
+        if isinstance(value, _dt.datetime):
+            if value.tzinfo is None:
+                value = value.replace(tzinfo=_dt.timezone.utc)
+            metadata[attr] = value.astimezone(_dt.timezone.utc).isoformat()
+    return metadata
+
+
+def parse_docx(path: Path) -> ParsedDocument:
+    """Parse a Microsoft Word document and extract headings and body content."""
+
+    try:
+        from docx import Document  # type: ignore[import-untyped]
+    except ImportError as exc:  # pragma: no cover - defensive
+        raise ParserError("python-docx is required to parse DOCX files") from exc
+
+    document = Document(path)
+    metadata = _extract_core_properties(document)
+
+    sections: list[DocumentSection] = []
+    current_section: DocumentSection | None = None
+    body_parts: list[str] = []
+
+    for paragraph in document.paragraphs:
+        text = paragraph.text.strip()
+        if not text:
+            continue
+        body_parts.append(text)
+        style_name = paragraph.style.name if paragraph.style is not None else ""
+        if style_name.lower().startswith("heading"):
+            try:
+                level = int("".join(filter(str.isdigit, style_name)))
+            except ValueError:
+                level = None
+            current_section = DocumentSection(title=text, content="", level=level)
+            sections.append(current_section)
+            continue
+        if current_section is None:
+            current_section = DocumentSection(title=None, content="")
+            sections.append(current_section)
+        if current_section.content:
+            current_section.content += "\n"
+        current_section.content += text
+
+    # Remove empty trailing sections to keep output compact.
+    sections = [section for section in sections if section.content or section.title]
+    pages = [PageContent(number=1, text="\n".join(body_parts))]
+    combined = "\n".join(body_parts)
+    metadata.setdefault("paragraph_count", len(document.paragraphs))
+    return ParsedDocument(text=combined, metadata=metadata, sections=sections, pages=pages)

--- a/app/ingest/parsers/markdown_parser.py
+++ b/app/ingest/parsers/markdown_parser.py
@@ -1,0 +1,39 @@
+"""Markdown parser that preserves heading hierarchy."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from . import DocumentSection, PageContent, ParsedDocument
+
+_HEADING_RE = re.compile(r"^(?P<level>#{1,6})\s*(?P<title>.+)$")
+
+
+def parse_markdown(path: Path) -> ParsedDocument:
+    """Parse a Markdown file into sections based on heading levels."""
+
+    text = path.read_text(encoding="utf-8")
+    sections: list[DocumentSection] = []
+    current_section: DocumentSection | None = None
+    body_lines: list[str] = []
+
+    for line in text.splitlines():
+        match = _HEADING_RE.match(line.strip())
+        if match:
+            level = len(match.group("level"))
+            title = match.group("title").strip()
+            current_section = DocumentSection(title=title, content="", level=level)
+            sections.append(current_section)
+            continue
+        if current_section is None:
+            current_section = DocumentSection(title=None, content="")
+            sections.append(current_section)
+        current_section.content += ("\n" if current_section.content else "") + line.rstrip()
+        body_lines.append(line.rstrip())
+
+    sections = [section for section in sections if section.content or section.title]
+    combined = "\n".join(body_lines)
+    pages = [PageContent(number=1, text=combined)]
+    metadata = {"format": "markdown", "heading_count": len([s for s in sections if s.title])}
+    return ParsedDocument(text=combined, metadata=metadata, sections=sections, pages=pages)

--- a/app/ingest/parsers/pdf_parser.py
+++ b/app/ingest/parsers/pdf_parser.py
@@ -1,0 +1,93 @@
+"""Utilities for extracting text and metadata from PDF files."""
+
+from __future__ import annotations
+
+import datetime as _dt
+from pathlib import Path
+from typing import Any
+
+from . import DocumentSection, PageContent, ParsedDocument, ParserError
+
+
+def _to_datetime(value: Any) -> str | None:
+    """Normalize a PyMuPDF metadata value into ISO format when possible."""
+
+    if isinstance(value, _dt.datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=_dt.timezone.utc)
+        return value.astimezone(_dt.timezone.utc).isoformat()
+    if isinstance(value, str):
+        try:
+            # PyMuPDF encodes dates as D:YYYYMMDDHHmmSS
+            cleaned = value.strip().lstrip("D:")
+            if cleaned:
+                parsed = _dt.datetime.strptime(cleaned[:14], "%Y%m%d%H%M%S")
+                return parsed.replace(tzinfo=_dt.timezone.utc).isoformat()
+        except ValueError:
+            return value
+        return None
+    return None
+
+
+def parse_pdf(path: Path) -> ParsedDocument:
+    """Parse ``path`` and extract textual content using PyMuPDF."""
+
+    try:
+        import fitz  # type: ignore[import-untyped]
+    except ImportError as exc:  # pragma: no cover - defensive
+        raise ParserError("PyMuPDF is required to parse PDF documents") from exc
+
+    try:
+        document = fitz.open(path)  # type: ignore[arg-type]
+    except fitz.FileDataError as exc:  # pragma: no cover - defensive
+        raise ParserError(str(exc)) from exc
+
+    try:
+        texts: list[str] = []
+        sections: list[DocumentSection] = []
+        pages: list[PageContent] = []
+        needs_ocr = True
+
+        for index, page in enumerate(document, start=1):
+            text = page.get_text("text")
+            if text.strip():
+                needs_ocr = False
+            texts.append(text.strip())
+            sections.append(
+                DocumentSection(
+                    title=f"Page {index}",
+                    content=text.strip(),
+                    level=1,
+                    page_number=index,
+                )
+            )
+            pages.append(PageContent(number=index, text=text))
+
+        metadata = {key: value for key, value in (document.metadata or {}).items() if value}
+        if document.page_count is not None:
+            metadata["page_count"] = int(document.page_count)
+
+        # Normalize datetime fields for consistency.
+        for key in ("creationDate", "modDate", "CreationDate", "ModDate"):
+            if key in metadata:
+                normalized = _to_datetime(metadata[key])
+                if normalized:
+                    metadata[key] = normalized
+
+        ocr_hint = (
+            "No extractable text detected. Consider running OCR before re-ingesting this PDF."
+            if needs_ocr
+            else None
+        )
+
+        combined_text = "\n\n".join(filter(None, texts))
+        return ParsedDocument(
+            text=combined_text,
+            metadata=metadata,
+            sections=sections,
+            pages=pages,
+            needs_ocr=needs_ocr,
+            ocr_hint=ocr_hint,
+        )
+    finally:
+        document.close()

--- a/app/ingest/parsers/text_parser.py
+++ b/app/ingest/parsers/text_parser.py
@@ -1,0 +1,30 @@
+"""Plain text parser with encoding detection."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from . import DocumentSection, PageContent, ParsedDocument
+
+
+def parse_text(path: Path) -> ParsedDocument:
+    """Parse a plain-text file while attempting to detect encoding."""
+
+    raw = path.read_bytes()
+    encoding = "utf-8"
+    try:
+        text = raw.decode(encoding)
+    except UnicodeDecodeError:
+        try:
+            import chardet  # type: ignore[import-untyped]
+        except ImportError:  # pragma: no cover - defensive
+            text = raw.decode(encoding, errors="replace")
+        else:
+            detected = chardet.detect(raw)
+            encoding = detected.get("encoding") or "utf-8"
+            text = raw.decode(encoding, errors="replace")
+
+    metadata = {"encoding": encoding}
+    sections = [DocumentSection(title=None, content=text)]
+    pages = [PageContent(number=1, text=text)]
+    return ParsedDocument(text=text, metadata=metadata, sections=sections, pages=pages)

--- a/app/ingest/preview.py
+++ b/app/ingest/preview.py
@@ -1,0 +1,128 @@
+"""Helpers for generating highlighted previews of ingested documents."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Iterable, Sequence
+
+from app.storage import DatabaseManager, IngestDocumentRepository
+
+
+class PreviewService:
+    """Provide highlighted passages and page retrieval for stored documents."""
+
+    def __init__(self, db: DatabaseManager) -> None:
+        self.db = db
+        self.documents = IngestDocumentRepository(db)
+
+    def get_highlighted_passages(
+        self,
+        document_id: int,
+        terms: Sequence[str] | None = None,
+        *,
+        context_chars: int = 240,
+    ) -> dict[str, Any]:
+        """Return a snippet with highlights for ``document_id``.
+
+        ``terms`` is treated as a case-insensitive set of tokens to emphasise in the
+        returned snippet. If no terms are supplied, the stored preview is returned.
+        """
+
+        record = self.documents.get(document_id)
+        if record is None:
+            raise LookupError(f"Unknown document id: {document_id}")
+
+        normalized = record.get("normalized_text") or record.get("text") or ""
+        snippet_source = normalized
+        if not snippet_source:
+            snippet_source = record.get("preview") or ""
+
+        if not terms:
+            snippet = record.get("preview") or snippet_source[:context_chars]
+            return self._assemble_preview(record, snippet, page=None, offset=0)
+
+        snippet, offset = self._build_highlight(snippet_source, terms, context_chars)
+        page_number = self._find_page(record.get("pages") or [], terms)
+        return self._assemble_preview(record, snippet, page=page_number, offset=offset)
+
+    def get_page(self, document_id: int, page_number: int) -> dict[str, Any]:
+        """Return the full text of ``page_number`` for ``document_id``."""
+
+        record = self.documents.get(document_id)
+        if record is None:
+            raise LookupError(f"Unknown document id: {document_id}")
+        for page in record.get("pages", []):
+            if int(page.get("number", -1)) == int(page_number):
+                return {
+                    "document_id": record["id"],
+                    "page_number": page_number,
+                    "text": page.get("text", ""),
+                }
+        raise LookupError(f"Page {page_number} not found for document {document_id}")
+
+    @staticmethod
+    def _apply_highlight(text: str, terms: Iterable[str]) -> str:
+        highlighted = text
+        for term in sorted({term for term in terms if term}, key=len, reverse=True):
+            pattern = re.compile(re.escape(term), re.IGNORECASE)
+            highlighted = pattern.sub(lambda match: f"<mark>{match.group(0)}</mark>", highlighted)
+        return highlighted
+
+    def _build_highlight(
+        self, text: str, terms: Sequence[str], context_chars: int
+    ) -> tuple[str, int]:
+        if not text:
+            return "", 0
+        lowered = text.lower()
+        best_index = None
+        for term in terms:
+            if not term:
+                continue
+            index = lowered.find(term.lower())
+            if index != -1 and (best_index is None or index < best_index):
+                best_index = index
+        if best_index is None:
+            snippet = text[:context_chars]
+            return self._apply_highlight(snippet, terms), 0
+        start = max(best_index - context_chars // 2, 0)
+        end = min(start + context_chars, len(text))
+        snippet = text[start:end]
+        return self._apply_highlight(snippet, terms), start
+
+    @staticmethod
+    def _find_page(pages: list[dict[str, Any]], terms: Sequence[str]) -> int | None:
+        lowered_terms = [term.lower() for term in terms if term]
+        for page in pages:
+            content = (page.get("text") or "").lower()
+            if any(term in content for term in lowered_terms):
+                try:
+                    return int(page.get("number"))
+                except (TypeError, ValueError):
+                    return None
+        return None
+
+    @staticmethod
+    def _assemble_preview(
+        record: dict[str, Any],
+        snippet: str,
+        *,
+        page: int | None,
+        offset: int,
+    ) -> dict[str, Any]:
+        return {
+            "document_id": record.get("id"),
+            "path": record.get("path"),
+            "version": record.get("version"),
+            "snippet": snippet,
+            "offset": offset,
+            "preview": record.get("preview"),
+            "needs_ocr": record.get("needs_ocr", False),
+            "ocr_message": record.get("ocr_message"),
+            "page": page,
+            "pages": record.get("pages"),
+            "sections": record.get("sections"),
+            "metadata": record.get("metadata"),
+        }
+
+
+__all__ = ["PreviewService"]

--- a/app/storage/__init__.py
+++ b/app/storage/__init__.py
@@ -7,6 +7,7 @@ from .database import (
     DatabaseError,
     DatabaseManager,
     DocumentRepository,
+    IngestDocumentRepository,
     ProjectRepository,
 )
 
@@ -17,5 +18,6 @@ __all__ = [
     "DatabaseError",
     "DatabaseManager",
     "DocumentRepository",
+    "IngestDocumentRepository",
     "ProjectRepository",
 ]

--- a/app/storage/schema.sql
+++ b/app/storage/schema.sql
@@ -142,3 +142,32 @@ CREATE TABLE IF NOT EXISTS background_task_logs (
     created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
     completed_at TEXT
 );
+
+CREATE TABLE IF NOT EXISTS ingest_documents (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    path TEXT NOT NULL,
+    version INTEGER NOT NULL,
+    checksum TEXT,
+    size INTEGER,
+    mtime REAL,
+    ctime REAL,
+    metadata TEXT,
+    text TEXT,
+    normalized_text TEXT,
+    preview TEXT,
+    sections TEXT,
+    pages TEXT,
+    needs_ocr INTEGER NOT NULL DEFAULT 0,
+    ocr_message TEXT,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(path, version)
+);
+
+CREATE INDEX IF NOT EXISTS idx_ingest_documents_path ON ingest_documents(path);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS ingest_document_index
+USING fts5(
+    content,
+    document_id UNINDEXED,
+    tokenize='porter'
+);

--- a/tests/test_preview_service.py
+++ b/tests/test_preview_service.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from app.ingest.parsers import parse_file
+from app.ingest.preview import PreviewService
+from app.storage import DatabaseManager, IngestDocumentRepository
+
+
+@pytest.fixture()
+def db_manager(tmp_path: Path) -> DatabaseManager:
+    db_path = tmp_path / "preview.db"
+    manager = DatabaseManager(db_path)
+    manager.initialize()
+    yield manager
+    manager.close()
+
+
+def test_preview_highlights_terms(tmp_path: Path, db_manager: DatabaseManager) -> None:
+    file_path = tmp_path / "sample.txt"
+    file_path.write_text("Alpha beta gamma delta epsilon", encoding="utf-8")
+    parsed = parse_file(file_path)
+    checksum = hashlib.sha256(file_path.read_bytes()).hexdigest()
+    repo = IngestDocumentRepository(db_manager)
+    stored = repo.store_version(
+        path=str(file_path),
+        checksum=checksum,
+        size=file_path.stat().st_size,
+        mtime=file_path.stat().st_mtime,
+        ctime=file_path.stat().st_ctime,
+        parsed=parsed,
+        base_metadata={"file": {"size": file_path.stat().st_size}},
+    )
+
+    preview = PreviewService(db_manager)
+    result = preview.get_highlighted_passages(stored["id"], ["gamma"])
+    assert "<mark>gamma</mark>" in result["snippet"]
+    assert result["page"] == 1 or result["page"] is None
+    page = preview.get_page(stored["id"], 1)
+    assert "Alpha" in page["text"]
+
+    results = repo.search("gamma")
+    assert results
+    assert "<mark>gamma</mark>" in results[0]["highlight"]


### PR DESCRIPTION
## Summary
- add a parser framework with PDF, DOCX, Markdown, and text extractors that capture structure and OCR diagnostics
- persist parsed content, normalized previews, and per-document FTS indexes via the ingest document repository
- provide a preview service for highlighted snippets and extend ingestion tests for OCR detection and previews

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d34ff8441c8322ba25ab013242f22c