### PR TITLE
Implement tagging, hierarchy, and search services

### DIFF
--- a/app/retrieval/__init__.py
+++ b/app/retrieval/__init__.py
@@ -1,3 +1,5 @@
 """Information retrieval components for the DataMiner application."""
 
-__all__: list[str] = []
+from .search import SearchService
+
+__all__ = ["SearchService"]

--- a/app/retrieval/search.py
+++ b/app/retrieval/search.py
@@ -1,0 +1,115 @@
+"""Keyword search helpers that bridge the ingest index and project metadata."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Iterable
+
+from app.storage import ChatRepository, DocumentRepository, IngestDocumentRepository
+
+
+class SearchService:
+    """Expose keyword search results with metadata and reusable scopes."""
+
+    def __init__(
+        self,
+        ingest_repository: IngestDocumentRepository,
+        document_repository: DocumentRepository,
+        chat_repository: ChatRepository,
+    ) -> None:
+        self.ingest = ingest_repository
+        self.documents = document_repository
+        self.chats = chat_repository
+
+    def search_documents(
+        self,
+        query: str,
+        *,
+        project_id: int,
+        limit: int = 5,
+        chat_id: int | None = None,
+        tags: Iterable[int] | None = None,
+        folder: str | Path | None = None,
+        recursive: bool = True,
+        save_scope: bool = False,
+    ) -> list[dict[str, Any]]:
+        """Search the ingest index and join results with project documents."""
+
+        scope_tags, scope_folder = self._resolve_scope(
+            chat_id,
+            tags,
+            folder,
+            save_scope=save_scope,
+        )
+        candidate_documents = self.documents.list_for_scope(
+            project_id,
+            tags=scope_tags,
+            folder=scope_folder,
+            recursive=recursive,
+        )
+        documents_by_path = self._build_path_index(candidate_documents)
+        results: list[dict[str, Any]] = []
+        for record in self.ingest.search(query, limit=limit * 3):
+            path = record.get("path")
+            if not path:
+                continue
+            document = documents_by_path.get(path)
+            if document is None:
+                continue
+            results.append(
+                {
+                    "document": document,
+                    "highlight": record.get("highlight") or record.get("preview"),
+                    "ingest_document": record,
+                }
+            )
+            if len(results) >= limit:
+                break
+        return results
+
+    def _resolve_scope(
+        self,
+        chat_id: int | None,
+        tags: Iterable[int] | None,
+        folder: str | Path | None,
+        *,
+        save_scope: bool,
+    ) -> tuple[list[int] | None, str | None]:
+        explicit_tags = list(tags) if tags is not None else None
+        explicit_folder = self._normalize_folder(folder) if folder is not None else None
+
+        stored_scope: dict[str, Any] = {}
+        if chat_id is not None:
+            stored_scope = self.chats.get_query_scope(chat_id) or {}
+
+        scope_tags = explicit_tags if explicit_tags is not None else stored_scope.get("tags")
+        scope_folder = explicit_folder if folder is not None else stored_scope.get("folder")
+
+        if chat_id is not None and save_scope:
+            payload = {
+                "tags": explicit_tags or [],
+                "folder": explicit_folder,
+            }
+            self.chats.set_query_scope(chat_id, payload)
+
+        return scope_tags, scope_folder
+
+    def _build_path_index(self, documents: Iterable[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+        index: dict[str, dict[str, Any]] = {}
+        for document in documents:
+            source_path = document.get("source_path")
+            if not source_path:
+                continue
+            normalized = self._normalize_path(source_path)
+            index[normalized] = document
+        return index
+
+    @staticmethod
+    def _normalize_path(path: str | Path) -> str:
+        return str(Path(path))
+
+    @staticmethod
+    def _normalize_folder(folder: str | Path | None) -> str | None:
+        if folder in (None, ""):
+            return None
+        return str(Path(folder))

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,3 +1,5 @@
 """Background services for the DataMiner application."""
 
-__all__: list[str] = []
+from .document_hierarchy import DocumentHierarchyService
+
+__all__ = ["DocumentHierarchyService"]

--- a/app/services/document_hierarchy.py
+++ b/app/services/document_hierarchy.py
@@ -1,0 +1,161 @@
+"""Services for building document hierarchies and metadata views."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Iterable
+
+from app.storage import DocumentRepository
+
+
+class DocumentHierarchyService:
+    """Provide hierarchical views of documents for the UI layer."""
+
+    def __init__(self, documents: DocumentRepository) -> None:
+        self.documents = documents
+
+    def build_folder_tree(self, project_id: int) -> dict[str, Any]:
+        """Return a nested folder tree with documents attached at each node."""
+
+        documents = self.documents.list_for_project(project_id)
+        base_path = self._determine_base_path(documents)
+        root = self._create_node(name="", path=str(base_path) if base_path is not None else None)
+        index: dict[str | None, dict[str, Any]] = {None: root}
+        for document in documents:
+            folder = self._normalize_folder(document.get("folder_path"))
+            relative = self._relative_folder(folder, base_path)
+            for ancestor in self._iter_folder_paths(relative):
+                if ancestor not in index:
+                    parent = self._parent_folder_key(ancestor)
+                    parent_node = index[parent]
+                    absolute_path = self._absolute_path(base_path, ancestor)
+                    node = self._create_node(name=self._node_name(ancestor), path=absolute_path)
+                    parent_node["children"].append(node)
+                    index[ancestor] = node
+            index[relative]["documents"].append(document)
+        self._sort_tree(root)
+        return root
+
+    def list_documents_for_scope(
+        self,
+        project_id: int,
+        *,
+        tags: Iterable[int] | None = None,
+        folder: str | Path | None = None,
+        recursive: bool = True,
+    ) -> list[dict[str, Any]]:
+        """Return documents matching ``tags``/``folder`` enriched with tag metadata."""
+
+        documents = self.documents.list_for_scope(
+            project_id,
+            tags=tags,
+            folder=folder,
+            recursive=recursive,
+        )
+        return [self._with_tags(document) for document in documents]
+
+    def get_document_view(self, document_id: int) -> dict[str, Any] | None:
+        """Return a metadata view for ``document_id`` including its tags."""
+
+        document = self.documents.get(document_id)
+        if document is None:
+            return None
+        return self._with_tags(document)
+
+    def refresh_tag_counts(self, project_id: int | None = None) -> None:
+        """Recalculate tag counts via the repository helper."""
+
+        self.documents.refresh_tag_counts(project_id)
+
+    @staticmethod
+    def _normalize_folder(folder: Any) -> str | None:
+        if folder in (None, ""):
+            return None
+        return str(Path(folder))
+
+    @staticmethod
+    def _relative_folder(folder: str | None, base_path: Path | None) -> str | None:
+        if folder is None:
+            return None
+        if base_path is None:
+            return str(Path(folder))
+        folder_path = Path(folder)
+        try:
+            relative = folder_path.relative_to(base_path)
+        except ValueError:
+            return str(folder_path)
+        relative_str = str(relative)
+        return None if relative_str in ("", ".") else relative_str
+
+    @staticmethod
+    def _absolute_path(base_path: Path | None, relative: str | None) -> str | None:
+        if relative in (None, ""):
+            return str(base_path) if base_path is not None else None
+        if base_path is None:
+            return str(Path(relative))
+        return str((base_path / relative))
+
+    @staticmethod
+    def _node_name(path: str | None) -> str:
+        if path is None:
+            return ""
+        name = Path(path).name
+        return name or str(Path(path))
+
+    @staticmethod
+    def _create_node(*, name: str, path: str | None) -> dict[str, Any]:
+        return {"name": name, "path": path, "documents": [], "children": []}
+
+    @staticmethod
+    def _parent_folder_key(path: str | None) -> str | None:
+        if path in (None, "", "."):
+            return None
+        current = Path(path)
+        parent = current.parent
+        parent_str = str(parent)
+        if parent == current or parent_str in ("", "."):
+            return None
+        return parent_str
+
+    @staticmethod
+    def _iter_folder_paths(folder: str | None) -> Iterable[str | None]:
+        yield None
+        if folder in (None, "", "."):
+            return
+        path = Path(folder)
+        ancestors: list[Path] = []
+        current = path
+        while True:
+            ancestors.append(current)
+            parent = current.parent
+            parent_str = str(parent)
+            if parent == current or parent_str in ("", "."):
+                break
+            current = parent
+        for ancestor in reversed(ancestors):
+            yield str(ancestor)
+
+    @staticmethod
+    def _determine_base_path(documents: Iterable[dict[str, Any]]) -> Path | None:
+        folders = [Path(doc["folder_path"]) for doc in documents if doc.get("folder_path")]
+        if not folders:
+            return None
+        base = folders[0]
+        for folder in folders[1:]:
+            while not folder.is_relative_to(base):
+                base = base.parent
+                if base.parent == base:
+                    break
+        return base
+
+    def _with_tags(self, document: dict[str, Any]) -> dict[str, Any]:
+        enriched = dict(document)
+        enriched["tags"] = self.documents.list_tags_for_document(document["id"])
+        return enriched
+
+    def _sort_tree(self, node: dict[str, Any]) -> None:
+        node["documents"].sort(key=lambda item: (item.get("title") or "").lower())
+        children = node["children"]
+        children.sort(key=lambda item: item["name"].lower())
+        for child in children:
+            self._sort_tree(child)

--- a/app/storage/schema.sql
+++ b/app/storage/schema.sql
@@ -22,6 +22,7 @@ CREATE TABLE IF NOT EXISTS documents (
     title TEXT NOT NULL,
     source_type TEXT,
     source_path TEXT,
+    folder_path TEXT,
     metadata TEXT,
     created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -53,6 +54,7 @@ CREATE TABLE IF NOT EXISTS tags (
     name TEXT NOT NULL,
     description TEXT,
     color TEXT,
+    document_count INTEGER NOT NULL DEFAULT 0,
     created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
     UNIQUE(project_id, name),
     FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE
@@ -88,6 +90,7 @@ CREATE TABLE IF NOT EXISTS chats (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     project_id INTEGER NOT NULL,
     title TEXT,
+    query_scope TEXT,
     created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE
@@ -164,6 +167,9 @@ CREATE TABLE IF NOT EXISTS ingest_documents (
 );
 
 CREATE INDEX IF NOT EXISTS idx_ingest_documents_path ON ingest_documents(path);
+
+CREATE INDEX IF NOT EXISTS idx_documents_project_folder
+ON documents(project_id, folder_path);
 
 CREATE VIRTUAL TABLE IF NOT EXISTS ingest_document_index
 USING fts5(

--- a/tests/test_search_service.py
+++ b/tests/test_search_service.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.ingest.parsers import ParsedDocument
+from app.retrieval import SearchService
+from app.services import DocumentHierarchyService
+from app.storage import (
+    ChatRepository,
+    DatabaseManager,
+    DocumentRepository,
+    IngestDocumentRepository,
+    ProjectRepository,
+)
+
+
+@pytest.fixture()
+def database(tmp_path: Path) -> DatabaseManager:
+    db_path = tmp_path / "dataminer.db"
+    manager = DatabaseManager(db_path)
+    manager.initialize()
+    yield manager
+    manager.close()
+
+
+@pytest.fixture()
+def project_repo(database: DatabaseManager) -> ProjectRepository:
+    return ProjectRepository(database)
+
+
+@pytest.fixture()
+def document_repo(database: DatabaseManager) -> DocumentRepository:
+    return DocumentRepository(database)
+
+
+@pytest.fixture()
+def ingest_repo(database: DatabaseManager) -> IngestDocumentRepository:
+    return IngestDocumentRepository(database)
+
+
+@pytest.fixture()
+def chat_repo(database: DatabaseManager) -> ChatRepository:
+    return ChatRepository(database)
+
+
+def _store_ingest_document(
+    repo: IngestDocumentRepository,
+    path: Path,
+    text: str,
+) -> None:
+    parsed = ParsedDocument(text=text, metadata={})
+    repo.store_version(
+        path=str(path),
+        checksum=None,
+        size=None,
+        mtime=None,
+        ctime=None,
+        parsed=parsed,
+    )
+
+
+def test_search_service_scope_and_highlight(
+    tmp_path: Path,
+    project_repo: ProjectRepository,
+    document_repo: DocumentRepository,
+    ingest_repo: IngestDocumentRepository,
+    chat_repo: ChatRepository,
+) -> None:
+    base = tmp_path / "corpus"
+    alpha_path = base / "alpha" / "spec.txt"
+    beta_path = base / "beta" / "notes.txt"
+    alpha_path.parent.mkdir(parents=True)
+    beta_path.parent.mkdir(parents=True)
+    alpha_path.write_text("Alpha specification includes the starlight keyword.")
+    beta_path.write_text("Beta notes mention starlight from another source.")
+
+    project = project_repo.create("Search Project")
+    doc_alpha = document_repo.create(project["id"], "Alpha", source_path=alpha_path)
+    doc_beta = document_repo.create(project["id"], "Beta", source_path=beta_path)
+
+    tag_focus = document_repo.create_tag(project["id"], "focus")
+    tag_other = document_repo.create_tag(project["id"], "other")
+    document_repo.tag_document(doc_alpha["id"], tag_focus["id"])
+    document_repo.tag_document(doc_beta["id"], tag_other["id"])
+
+    _store_ingest_document(ingest_repo, alpha_path, alpha_path.read_text())
+    _store_ingest_document(ingest_repo, beta_path, beta_path.read_text())
+
+    chat = chat_repo.create(project["id"], "Analysis")
+    service = SearchService(ingest_repo, document_repo, chat_repo)
+
+    first_results = service.search_documents(
+        "starlight",
+        project_id=project["id"],
+        chat_id=chat["id"],
+        tags=[tag_focus["id"]],
+        save_scope=True,
+    )
+    assert [item["document"]["id"] for item in first_results] == [doc_alpha["id"]]
+    assert "<mark>starlight</mark>" in first_results[0]["highlight"]
+
+    follow_up = service.search_documents(
+        "starlight",
+        project_id=project["id"],
+        chat_id=chat["id"],
+    )
+    assert [item["document"]["id"] for item in follow_up] == [doc_alpha["id"]]
+
+    beta_folder = document_repo.get(doc_beta["id"])["folder_path"]
+    updated_results = service.search_documents(
+        "starlight",
+        project_id=project["id"],
+        chat_id=chat["id"],
+        tags=[tag_other["id"]],
+        folder=beta_folder,
+        save_scope=True,
+    )
+    assert [item["document"]["id"] for item in updated_results] == [doc_beta["id"]]
+
+
+def test_document_hierarchy_service(
+    tmp_path: Path,
+    project_repo: ProjectRepository,
+    document_repo: DocumentRepository,
+) -> None:
+    base = tmp_path / "hier"
+    first = base / "alpha" / "doc1.txt"
+    second = base / "alpha" / "deep" / "doc2.txt"
+    third = base / "beta" / "doc3.txt"
+    third.parent.mkdir(parents=True, exist_ok=True)
+    second.parent.mkdir(parents=True, exist_ok=True)
+    first.parent.mkdir(parents=True, exist_ok=True)
+    first.write_text("one")
+    second.write_text("two")
+    third.write_text("three")
+
+    project = project_repo.create("Hierarchy")
+    doc_one = document_repo.create(project["id"], "One", source_path=first)
+    doc_two = document_repo.create(project["id"], "Two", source_path=second)
+    doc_three = document_repo.create(project["id"], "Three", source_path=third)
+
+    tag_deep = document_repo.create_tag(project["id"], "deep")
+    document_repo.tag_document(doc_two["id"], tag_deep["id"])
+
+    hierarchy = DocumentHierarchyService(document_repo)
+    tree = hierarchy.build_folder_tree(project["id"])
+    top_level = [child["name"] for child in tree["children"]]
+    assert top_level == sorted(top_level)
+    assert {child["name"] for child in tree["children"]} == {"alpha", "beta"}
+
+    alpha_node = next(child for child in tree["children"] if child["name"] == "alpha")
+    assert {doc["title"] for doc in alpha_node["documents"]} == {"One"}
+
+    deep_node = next(child for child in alpha_node["children"] if child["name"] == "deep")
+    assert {doc["title"] for doc in deep_node["documents"]} == {"Two"}
+
+    beta_node = next(child for child in tree["children"] if child["name"] == "beta")
+    assert {doc["title"] for doc in beta_node["documents"]} == {"Three"}
+
+    view = hierarchy.get_document_view(doc_two["id"])
+    assert view is not None
+    assert {tag["name"] for tag in view["tags"]} == {"deep"}
+
+    scoped = hierarchy.list_documents_for_scope(project["id"], tags=[tag_deep["id"]])
+    assert [doc["id"] for doc in scoped] == [doc_two["id"]]
+    assert scoped[0]["tags"][0]["name"] == "deep"


### PR DESCRIPTION
## Summary
- extend the storage layer with folder-aware document queries, tag count maintenance, and chat query scope persistence
- add document hierarchy and search services that surface folder trees, tag-enriched document views, and highlighted keyword results
- update the schema for folder paths, tag usage counts, and chat query scopes with accompanying unit tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d353bb7f8883228a82cbe30a82ff0e