### PR TITLE
Add LMStudio client with conversation management

### DIFF
--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,5 +1,29 @@
 """Background services for the DataMiner application."""
 
+from .conversation_manager import (
+    AnswerLength,
+    ConnectionState,
+    ConversationManager,
+    ConversationTurn,
+)
 from .document_hierarchy import DocumentHierarchyService
+from .lmstudio_client import (
+    ChatMessage,
+    LMStudioClient,
+    LMStudioConnectionError,
+    LMStudioError,
+    LMStudioResponseError,
+)
 
-__all__ = ["DocumentHierarchyService"]
+__all__ = [
+    "AnswerLength",
+    "ChatMessage",
+    "ConnectionState",
+    "ConversationManager",
+    "ConversationTurn",
+    "DocumentHierarchyService",
+    "LMStudioClient",
+    "LMStudioConnectionError",
+    "LMStudioError",
+    "LMStudioResponseError",
+]

--- a/app/services/conversation_manager.py
+++ b/app/services/conversation_manager.py
@@ -1,0 +1,161 @@
+"""Stateful helpers for coordinating LMStudio conversations."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+from .lmstudio_client import (
+    AnswerLength,
+    ChatMessage,
+    LMStudioClient,
+    LMStudioConnectionError,
+    LMStudioError,
+)
+
+
+@dataclass
+class ConversationTurn:
+    """Record of a single question/answer exchange."""
+
+    question: str
+    answer: str
+    citations: list[Any] = field(default_factory=list)
+    reasoning: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class ConnectionState:
+    """Connection status event payload."""
+
+    connected: bool
+    message: str | None = None
+
+
+class ConversationManager:
+    """Track conversation history and orchestrate LMStudio requests."""
+
+    def __init__(
+        self,
+        client: LMStudioClient,
+        *,
+        system_prompt: str | None = None,
+        context_window: int = 4,
+    ) -> None:
+        self.client = client
+        self.system_prompt = system_prompt
+        self.context_window = max(0, context_window)
+        self.turns: list[ConversationTurn] = []
+        self._connected = True
+        self._connection_error: str | None = None
+        self._listeners: list[Callable[[ConnectionState], None]] = []
+
+    def add_connection_listener(
+        self, listener: Callable[[ConnectionState], None]
+    ) -> Callable[[], None]:
+        """Subscribe to connection changes and return an unsubscribe callable."""
+
+        self._listeners.append(listener)
+
+        def unsubscribe() -> None:
+            if listener in self._listeners:
+                self._listeners.remove(listener)
+
+        return unsubscribe
+
+    @property
+    def connection_state(self) -> ConnectionState:
+        return ConnectionState(self._connected, self._connection_error)
+
+    def check_connection(self) -> ConnectionState:
+        """Probe LMStudio and update connection state."""
+
+        healthy = self.client.health_check()
+        if healthy:
+            self._update_connection(True, None)
+        else:
+            self._update_connection(False, "LMStudio is unreachable. Check the base URL.")
+        return self.connection_state
+
+    def can_ask(self) -> bool:
+        """Return ``True`` when it is safe to issue a new query."""
+
+        return self._connected
+
+    def ask(
+        self,
+        question: str,
+        *,
+        context_snippets: Sequence[str] | None = None,
+        preset: AnswerLength = AnswerLength.NORMAL,
+        extra_options: dict[str, Any] | None = None,
+    ) -> ConversationTurn:
+        """Send ``question`` to LMStudio and append the resulting turn."""
+
+        if not self._connected:
+            message = self._connection_error or "LMStudio is disconnected."
+            raise LMStudioConnectionError(message)
+
+        messages = self._build_messages(question, context_snippets)
+        try:
+            response = self.client.chat(messages, preset=preset, extra_options=extra_options)
+        except LMStudioError as exc:
+            self._update_connection(False, str(exc) or "Unable to reach LMStudio.")
+            raise
+
+        self._update_connection(True, None)
+        turn = self._register_turn(question, response)
+        return turn
+
+    def _register_turn(self, question: str, response: ChatMessage) -> ConversationTurn:
+        turn = ConversationTurn(
+            question=question,
+            answer=response.content,
+            citations=response.citations,
+            reasoning=response.reasoning,
+        )
+        self.turns.append(turn)
+        return turn
+
+    def _build_messages(
+        self, question: str, context_snippets: Sequence[str] | None
+    ) -> list[dict[str, Any]]:
+        messages: list[dict[str, Any]] = []
+        if self.system_prompt:
+            messages.append({"role": "system", "content": self.system_prompt})
+        history = self.turns[-self.context_window :] if self.context_window else []
+        for turn in history:
+            messages.append({"role": "user", "content": turn.question})
+            messages.append({"role": "assistant", "content": turn.answer})
+
+        user_content = question
+        if context_snippets:
+            formatted_context = "\n\n".join(context_snippets)
+            user_content = f"{question}\n\nContext:\n{formatted_context}"
+        messages.append({"role": "user", "content": user_content})
+        return messages
+
+    def _update_connection(self, connected: bool, message: str | None) -> None:
+        state_changed = connected != self._connected or message != self._connection_error
+        self._connected = connected
+        self._connection_error = message
+        if state_changed:
+            self._emit_connection_state()
+
+    def _emit_connection_state(self) -> None:
+        state = self.connection_state
+        for listener in list(self._listeners):
+            try:
+                listener(state)
+            except Exception:  # pragma: no cover - defensive guard
+                continue
+
+
+__all__ = [
+    "AnswerLength",
+    "ConnectionState",
+    "ConversationManager",
+    "ConversationTurn",
+]
+

--- a/app/services/lmstudio_client.py
+++ b/app/services/lmstudio_client.py
@@ -1,0 +1,221 @@
+"""Client helpers for interacting with a local LMStudio HTTP server."""
+
+from __future__ import annotations
+
+import json
+import time
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+from urllib import error, request
+
+
+DEFAULT_BASE_URL = "http://127.0.0.1:1234"
+CHAT_COMPLETIONS_PATH = "/v1/chat/completions"
+HEALTH_PATH = "/v1/health"
+
+
+class LMStudioError(RuntimeError):
+    """Base exception for LMStudio client failures."""
+
+
+class LMStudioConnectionError(LMStudioError):
+    """Raised when the LMStudio server cannot be reached."""
+
+
+class LMStudioResponseError(LMStudioError):
+    """Raised when the LMStudio server returns an invalid response."""
+
+
+@dataclass(frozen=True)
+class ChatMessage:
+    """Structured data for a chat completion response."""
+
+    content: str
+    citations: list[Any]
+    reasoning: dict[str, Any] | None
+    raw_response: dict[str, Any]
+
+
+class AnswerLength(Enum):
+    """Presets that control completion verbosity."""
+
+    BRIEF = "brief"
+    NORMAL = "normal"
+    DETAILED = "detailed"
+
+    def to_request_params(self) -> dict[str, Any]:
+        """Return request parameter overrides for the preset."""
+
+        if self is AnswerLength.BRIEF:
+            return {"max_tokens": 256, "temperature": 0.2}
+        if self is AnswerLength.DETAILED:
+            return {"max_tokens": 1024, "temperature": 0.4}
+        return {"max_tokens": 512, "temperature": 0.3}
+
+
+class LMStudioClient:
+    """Simple HTTP client for LMStudio's OpenAI-compatible API."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str = DEFAULT_BASE_URL,
+        model: str = "lmstudio",
+        timeout: float = 30.0,
+        max_retries: int = 2,
+        retry_backoff: float = 0.5,
+    ) -> None:
+        self._base_url = base_url.rstrip("/") or DEFAULT_BASE_URL
+        self._model = model
+        self.timeout = timeout
+        self.max_retries = max(max_retries, 0)
+        self.retry_backoff = retry_backoff
+
+    @property
+    def base_url(self) -> str:
+        return self._base_url
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    def configure(
+        self,
+        *,
+        base_url: str | None = None,
+        model: str | None = None,
+    ) -> None:
+        """Update connection settings without recreating the client."""
+
+        if base_url is not None:
+            normalized = base_url.rstrip("/")
+            self._base_url = normalized or DEFAULT_BASE_URL
+        if model is not None:
+            self._model = model
+
+    def health_check(self) -> bool:
+        """Return ``True`` if the LMStudio server responds to a health probe."""
+
+        try:
+            self._request("GET", HEALTH_PATH)
+        except LMStudioError:
+            return False
+        return True
+
+    def chat(
+        self,
+        messages: Sequence[dict[str, Any]],
+        *,
+        preset: AnswerLength = AnswerLength.NORMAL,
+        extra_options: dict[str, Any] | None = None,
+    ) -> ChatMessage:
+        """Send chat ``messages`` to LMStudio and return the first completion."""
+
+        payload = {
+            "model": self._model,
+            "messages": list(messages),
+        }
+        payload.update(preset.to_request_params())
+        if extra_options:
+            payload.update(extra_options)
+        data = self._request_json("POST", CHAT_COMPLETIONS_PATH, payload)
+        return self._parse_chat_response(data)
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        payload: dict[str, Any] | None = None,
+    ) -> bytes:
+        url = f"{self._base_url}{path}"
+        data: bytes | None = None
+        headers = {"Accept": "application/json"}
+        if payload is not None:
+            data = json.dumps(payload).encode("utf-8")
+            headers["Content-Type"] = "application/json"
+        request_obj = request.Request(url, data=data, headers=headers, method=method)
+        last_error: Exception | None = None
+        for attempt in range(self.max_retries + 1):
+            try:
+                with request.urlopen(request_obj, timeout=self.timeout) as response:
+                    status = response.getcode()
+                    body = response.read()
+                if status >= 400:
+                    message = body.decode("utf-8", errors="replace") if body else ""
+                    raise LMStudioResponseError(
+                        f"LMStudio returned HTTP {status}: {message.strip()}"
+                    )
+                return body
+            except error.HTTPError as exc:
+                body = exc.read() if hasattr(exc, "read") else b""
+                message = body.decode("utf-8", errors="replace") if body else str(exc)
+                last_error = LMStudioResponseError(message)
+                if not self._should_retry(exc.code):
+                    break
+            except error.URLError as exc:
+                last_error = LMStudioConnectionError(str(exc.reason))
+            if attempt < self.max_retries:
+                time.sleep(self.retry_backoff * (2**attempt))
+        if isinstance(last_error, LMStudioError):
+            raise last_error
+        if last_error is not None:
+            raise LMStudioError(str(last_error))
+        raise LMStudioError("Unexpected LMStudio request failure")
+
+    def _request_json(
+        self, method: str, path: str, payload: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        body = self._request(method, path, payload)
+        if not body:
+            raise LMStudioResponseError("Empty response from LMStudio")
+        try:
+            return json.loads(body.decode("utf-8"))
+        except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+            raise LMStudioResponseError("Invalid JSON from LMStudio") from exc
+
+    @staticmethod
+    def _should_retry(status: int | None) -> bool:
+        if status is None:
+            return True
+        if status in {408, 409, 429, 500, 502, 503, 504}:
+            return True
+        return False
+
+    @staticmethod
+    def _parse_chat_response(data: dict[str, Any]) -> ChatMessage:
+        choices = data.get("choices")
+        if not isinstance(choices, Iterable):
+            raise LMStudioResponseError("LMStudio response missing choices")
+        first = next(iter(choices), None)
+        if not isinstance(first, dict):
+            raise LMStudioResponseError("LMStudio response missing first choice")
+        message = first.get("message")
+        if not isinstance(message, dict):
+            raise LMStudioResponseError("LMStudio response missing message")
+        content = message.get("content")
+        if not isinstance(content, str):
+            raise LMStudioResponseError("LMStudio message missing content")
+        metadata = message.get("metadata") if isinstance(message.get("metadata"), dict) else {}
+        citations = metadata.get("citations")
+        if not isinstance(citations, list):
+            citations = []
+        reasoning = metadata.get("reasoning") if isinstance(metadata.get("reasoning"), dict) else None
+        return ChatMessage(
+            content=content,
+            citations=citations,
+            reasoning=reasoning,
+            raw_response=data,
+        )
+
+
+__all__ = [
+    "AnswerLength",
+    "ChatMessage",
+    "LMStudioClient",
+    "LMStudioConnectionError",
+    "LMStudioError",
+    "LMStudioResponseError",
+]
+

--- a/tests/test_lmstudio_integration.py
+++ b/tests/test_lmstudio_integration.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import json
+import threading
+from collections.abc import Callable, Sequence
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+
+from app.services import (
+    AnswerLength,
+    ConversationManager,
+    LMStudioClient,
+    LMStudioConnectionError,
+    LMStudioError,
+)
+
+
+def _default_chat_response(payload: dict[str, object]) -> dict[str, object]:
+    messages = payload.get("messages")
+    if isinstance(messages, Sequence) and messages:
+        raw_question = messages[-1]
+        if isinstance(raw_question, dict):
+            question = str(raw_question.get("content", ""))
+        else:
+            question = ""
+    else:
+        question = ""
+    return {
+        "id": "chatcmpl-test",
+        "object": "chat.completion",
+        "created": 0,
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": f"Echo: {question}",
+                    "metadata": {
+                        "citations": [{"source": "doc1", "snippet": "alpha"}],
+                        "reasoning": {"steps": ["Review context", "Respond"]},
+                    },
+                },
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+    }
+
+
+def _make_handler(state: dict[str, object]) -> type[BaseHTTPRequestHandler]:
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802 - signature defined by BaseHTTPRequestHandler
+            if self.path == "/v1/health":
+                status = int(state.get("health_status", 200))
+                body = state.get("health_body", {"status": "ok"})
+                self.send_response(status)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                payload = json.dumps(body).encode("utf-8")
+                self.wfile.write(payload)
+            else:
+                self.send_response(404)
+                self.end_headers()
+
+        def do_POST(self) -> None:  # noqa: N802 - signature defined by BaseHTTPRequestHandler
+            length = int(self.headers.get("Content-Length", "0"))
+            raw_body = self.rfile.read(length)
+            try:
+                payload = json.loads(raw_body.decode("utf-8")) if raw_body else {}
+            except json.JSONDecodeError:
+                payload = {}
+            requests = state.setdefault("requests", [])
+            if isinstance(requests, list):
+                requests.append(payload)
+
+            responses = state.setdefault("responses", [])
+            current: dict[str, object]
+            if isinstance(responses, list) and responses:
+                current_raw = responses.pop(0)
+                if isinstance(current_raw, dict):
+                    current = current_raw
+                else:
+                    current = {"status": 200, "body": {}}
+            else:
+                template = state.get("response_template", _default_chat_response)
+                if isinstance(template, Callable):
+                    body = template(payload)
+                else:
+                    body = _default_chat_response(payload)
+                current = {"status": 200, "body": body}
+
+            status = int(current.get("status", 200))
+            body = current.get("body", {})
+            if not isinstance(body, (bytes, bytearray)):
+                body = json.dumps(body).encode("utf-8")
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, format: str, *args: object) -> None:  # noqa: D401, N802 - disable noisy logs
+            """Silence default request logging during tests."""
+
+    return Handler
+
+
+@pytest.fixture()
+def lmstudio_server() -> tuple[dict[str, object], str]:
+    state: dict[str, object] = {
+        "requests": [],
+        "responses": [],
+        "health_status": 200,
+        "health_body": {"status": "ok"},
+    }
+    handler = _make_handler(state)
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    base_url = f"http://{server.server_address[0]}:{server.server_address[1]}"
+    try:
+        yield state, base_url
+    finally:
+        server.shutdown()
+        thread.join()
+
+
+def test_lmstudio_client_and_conversation_manager_success(lmstudio_server: tuple[dict[str, object], str]) -> None:
+    state, base_url = lmstudio_server
+    client = LMStudioClient(base_url=base_url, model="test-model", max_retries=2, retry_backoff=0.01)
+    manager = ConversationManager(client, system_prompt="You are helpful.", context_window=2)
+
+    events: list[tuple[bool, str | None]] = []
+    manager.add_connection_listener(lambda payload: events.append((payload.connected, payload.message)))
+
+    connection_state = manager.check_connection()
+    assert connection_state.connected
+    if events:
+        assert events[-1][0] is True
+
+    turn = manager.ask(
+        "What is the summary?",
+        context_snippets=["Document A: important details."],
+        preset=AnswerLength.BRIEF,
+    )
+
+    assert turn.answer.startswith("Echo:")
+    assert turn.citations
+    assert turn.reasoning == {"steps": ["Review context", "Respond"]}
+
+    assert state["requests"] and isinstance(state["requests"], list)
+    payload = state["requests"][0]
+    assert payload["model"] == "test-model"
+    assert payload["max_tokens"] == AnswerLength.BRIEF.to_request_params()["max_tokens"]
+    messages = payload["messages"]
+    assert isinstance(messages, list)
+    # Expect system prompt, plus user/assistant pairs (none yet), and new user message.
+    assert messages[0]["role"] == "system"
+    assert "Context:" in messages[-1]["content"]
+
+
+def test_conversation_manager_handles_failures_and_recovers(
+    lmstudio_server: tuple[dict[str, object], str]
+) -> None:
+    state, base_url = lmstudio_server
+    client = LMStudioClient(base_url=base_url, max_retries=1, retry_backoff=0.01)
+    manager = ConversationManager(client, context_window=1)
+    events: list[tuple[bool, str | None]] = []
+    manager.add_connection_listener(lambda payload: events.append((payload.connected, payload.message)))
+
+    manager.check_connection()
+    state["responses"] = [
+        {"status": 500, "body": {"error": "temporary"}},
+    ]
+    turn = manager.ask("First question?")
+    assert turn.answer.startswith("Echo:")
+    assert len(state["requests"]) == 2
+
+    # Now exhaust retries with persistent errors.
+    state["responses"] = [
+        {"status": 503, "body": {"error": "down"}},
+        {"status": 503, "body": {"error": "still down"}},
+    ]
+    with pytest.raises(LMStudioError):
+        manager.ask("Second question?")
+    assert events[-1][0] is False
+    assert events[-1][1]
+    assert manager.can_ask() is False
+
+    with pytest.raises(LMStudioConnectionError):
+        manager.ask("Should not run")
+
+    # Restore health and verify context window behaviour.
+    state["health_status"] = 200
+    state["responses"] = []
+    recovery_state = manager.check_connection()
+    assert recovery_state.connected is True
+    assert manager.can_ask() is True
+    assert events[-1][0] is True
+
+    state["responses"] = []
+    state["requests"] = []
+    manager.ask("Follow-up?")
+    payload = state["requests"][0]
+    messages = payload["messages"]
+    assert len(messages) == 3  # previous user+assistant + new user
+    assert messages[0]["role"] == "user"
+    assert messages[0]["content"].startswith("First question?")
+    assert messages[1]["role"] == "assistant"
+


### PR DESCRIPTION
## Summary
- implement a configurable LMStudioClient with health checks, retries, and answer length presets
- add a ConversationManager that tracks turns, emits connection state changes, and manages follow-up context windows
- cover the new behaviour with mocked LMStudio integration tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d358a9ac648322aba5e9381b8e142e