### PR TITLE
Create main window UI with theme persistence and progress feedback

### DIFF
--- a/app/__main__.py
+++ b/app/__main__.py
@@ -4,9 +4,13 @@ from __future__ import annotations
 
 import sys
 
-from PyQt6.QtWidgets import QApplication, QLabel
+from PyQt6.QtWidgets import QApplication
 
 from .logging import setup_logging
+from .services.lmstudio_client import LMStudioClient
+from .services.progress_service import ProgressService
+from .services.settings_service import SettingsService
+from .ui import MainWindow
 
 
 def main() -> None:
@@ -17,9 +21,15 @@ def main() -> None:
     app = QApplication(sys.argv)
     app.setApplicationName("DataMiner")
 
-    window = QLabel("DataMiner is running.")
-    window.setWindowTitle("DataMiner")
-    window.resize(400, 200)
+    settings_service = SettingsService()
+    progress_service = ProgressService()
+    lmstudio_client = LMStudioClient()
+
+    window = MainWindow(
+        settings_service=settings_service,
+        progress_service=progress_service,
+        lmstudio_client=lmstudio_client,
+    )
     window.show()
 
     logger.info("Application started")

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -39,3 +39,19 @@ __all__ = [
     "LMStudioError",
     "LMStudioResponseError",
 ]
+
+# Optional UI services require PyQt6. They are imported lazily to avoid import
+# errors when the runtime environment lacks Qt libraries.
+try:  # pragma: no cover - optional dependency guard
+    from .progress_service import ProgressService, ProgressUpdate
+except ImportError:  # pragma: no cover
+    ProgressService = ProgressUpdate = None  # type: ignore[assignment]
+else:  # pragma: no cover - executed when Qt is available
+    __all__.extend(["ProgressService", "ProgressUpdate"])
+
+try:  # pragma: no cover - optional dependency guard
+    from .settings_service import SettingsService
+except ImportError:  # pragma: no cover
+    SettingsService = None  # type: ignore[assignment]
+else:  # pragma: no cover - executed when Qt is available
+    __all__.append("SettingsService")

--- a/app/services/progress_service.py
+++ b/app/services/progress_service.py
@@ -1,0 +1,103 @@
+"""Centralized progress and toast notification helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+from PyQt6.QtCore import QObject, pyqtSignal
+
+
+@dataclass(slots=True)
+class ProgressUpdate:
+    """Data object describing the state of a progress update."""
+
+    task_id: str
+    message: str
+    percent: float | None = None
+    indeterminate: bool = False
+
+
+class ProgressService(QObject):
+    """Publish background task progress to interested listeners."""
+
+    progress_started = pyqtSignal(object)
+    progress_updated = pyqtSignal(object)
+    progress_finished = pyqtSignal(object)
+    toast_requested = pyqtSignal(str, str, int)
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._subscriptions: list[Callable[[ProgressUpdate], None]] = []
+
+    # ------------------------------------------------------------------
+    # Subscription helpers
+    def subscribe(self, callback: Callable[[ProgressUpdate], None]) -> None:
+        """Subscribe ``callback`` to raw progress events."""
+
+        if callback not in self._subscriptions:
+            self._subscriptions.append(callback)
+
+    def unsubscribe(self, callback: Callable[[ProgressUpdate], None]) -> None:
+        """Remove ``callback`` from the subscription list."""
+
+        if callback in self._subscriptions:
+            self._subscriptions.remove(callback)
+
+    def _dispatch(self, update: ProgressUpdate) -> None:
+        for callback in list(self._subscriptions):
+            callback(update)
+
+    # ------------------------------------------------------------------
+    # Emission helpers
+    def start(self, task_id: str, message: str = "") -> None:
+        update = ProgressUpdate(task_id=task_id, message=message, percent=0.0)
+        self.progress_started.emit(update)
+        self._dispatch(update)
+
+    def update(
+        self,
+        task_id: str,
+        *,
+        message: str | None = None,
+        percent: float | None = None,
+        indeterminate: bool | None = None,
+    ) -> None:
+        update = ProgressUpdate(
+            task_id=task_id,
+            message=message or "",
+            percent=percent,
+            indeterminate=bool(indeterminate) if indeterminate is not None else False,
+        )
+        self.progress_updated.emit(update)
+        self._dispatch(update)
+
+    def finish(self, task_id: str, message: str = "") -> None:
+        update = ProgressUpdate(task_id=task_id, message=message, percent=100.0)
+        self.progress_finished.emit(update)
+        self._dispatch(update)
+
+    def notify(self, message: str, *, level: str = "info", duration_ms: int = 4000) -> None:
+        """Request a toast notification."""
+
+        self.toast_requested.emit(message, level, duration_ms)
+
+    # ------------------------------------------------------------------
+    # Background task integration
+    def subscribe_to(self, emitter: QObject) -> None:
+        """Connect a background task emitter with ``started/progress/finished`` signals."""
+
+        if hasattr(emitter, "started"):
+            emitter.started.connect(lambda task_id, message="": self.start(task_id, message))  # type: ignore[arg-type]
+        if hasattr(emitter, "progress"):
+            emitter.progress.connect(  # type: ignore[attr-defined]
+                lambda task_id, percent, message="": self.update(
+                    task_id, message=message, percent=percent
+                )
+            )
+        if hasattr(emitter, "finished"):
+            emitter.finished.connect(lambda task_id, message="": self.finish(task_id, message))  # type: ignore[arg-type]
+
+
+__all__ = ["ProgressService", "ProgressUpdate"]
+

--- a/app/services/settings_service.py
+++ b/app/services/settings_service.py
@@ -1,0 +1,153 @@
+"""Application settings management for UI preferences."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from PyQt6.QtCore import QObject, pyqtSignal
+from PyQt6.QtGui import QFont, QColor, QPalette
+from PyQt6.QtWidgets import QApplication
+
+from ..config import ConfigManager
+
+
+DEFAULT_THEME = "light"
+MIN_FONT_SCALE = 0.5
+MAX_FONT_SCALE = 2.5
+
+
+@dataclass(slots=True)
+class UISettings:
+    """Container for persisted UI settings."""
+
+    theme: str = DEFAULT_THEME
+    font_scale: float = 1.0
+
+
+class SettingsService(QObject):
+    """Persist and broadcast UI level settings such as theme and fonts."""
+
+    theme_changed = pyqtSignal(str)
+    font_scale_changed = pyqtSignal(float)
+
+    def __init__(self, config_manager: ConfigManager | None = None) -> None:
+        super().__init__()
+        self._config = config_manager or ConfigManager()
+        self._settings = UISettings()
+        self._base_font_point_size: float | None = None
+        self.reload()
+
+    # ------------------------------------------------------------------
+    # Persistence helpers
+    def reload(self) -> None:
+        """Reload settings from disk."""
+
+        data = self._config.load()
+        ui_settings = data.get("ui") if isinstance(data, dict) else {}
+        theme = str(ui_settings.get("theme", DEFAULT_THEME)).lower()
+        if theme not in {"light", "dark"}:
+            theme = DEFAULT_THEME
+        font_scale = ui_settings.get("font_scale", 1.0)
+        try:
+            font_scale = float(font_scale)
+        except (TypeError, ValueError):
+            font_scale = 1.0
+        font_scale = float(min(MAX_FONT_SCALE, max(MIN_FONT_SCALE, font_scale)))
+        self._settings = UISettings(theme=theme, font_scale=font_scale)
+        self._base_font_point_size = None
+
+    def save(self) -> None:
+        """Persist the current settings to disk."""
+
+        data = self._config.load()
+        if not isinstance(data, dict):
+            data = {}
+        ui_data = data.get("ui") if isinstance(data.get("ui"), dict) else {}
+        ui_data.update(
+            {
+                "theme": self._settings.theme,
+                "font_scale": self._settings.font_scale,
+            }
+        )
+        data["ui"] = ui_data
+        self._config.save(data)
+
+    # ------------------------------------------------------------------
+    # Accessors
+    @property
+    def theme(self) -> str:
+        return self._settings.theme
+
+    @property
+    def font_scale(self) -> float:
+        return self._settings.font_scale
+
+    # ------------------------------------------------------------------
+    # Mutators
+    def set_theme(self, theme: str) -> None:
+        normalized = "dark" if str(theme).lower() == "dark" else "light"
+        if normalized == self._settings.theme:
+            return
+        self._settings.theme = normalized
+        self.save()
+        self.theme_changed.emit(normalized)
+
+    def toggle_theme(self) -> None:
+        self.set_theme("dark" if self._settings.theme == "light" else "light")
+
+    def set_font_scale(self, scale: float) -> None:
+        try:
+            value = float(scale)
+        except (TypeError, ValueError):
+            return
+        value = float(min(MAX_FONT_SCALE, max(MIN_FONT_SCALE, value)))
+        if abs(value - self._settings.font_scale) < 1e-6:
+            return
+        self._settings.font_scale = value
+        self.save()
+        self.font_scale_changed.emit(value)
+
+    # ------------------------------------------------------------------
+    # Application helpers
+    def apply_theme(self, app: QApplication | None = None) -> None:
+        """Apply the current theme palette to the ``QApplication``."""
+
+        app = app or QApplication.instance()
+        if app is None:
+            return
+        if self._settings.theme == "dark":
+            palette = QPalette()
+            palette.setColor(QPalette.ColorRole.Window, QColor(30, 30, 30))
+            palette.setColor(QPalette.ColorRole.WindowText, QColor(220, 220, 220))
+            palette.setColor(QPalette.ColorRole.Base, QColor(25, 25, 25))
+            palette.setColor(QPalette.ColorRole.AlternateBase, QColor(53, 53, 53))
+            palette.setColor(QPalette.ColorRole.ToolTipBase, QColor(220, 220, 220))
+            palette.setColor(QPalette.ColorRole.ToolTipText, QColor(25, 25, 25))
+            palette.setColor(QPalette.ColorRole.Text, QColor(220, 220, 220))
+            palette.setColor(QPalette.ColorRole.Button, QColor(53, 53, 53))
+            palette.setColor(QPalette.ColorRole.ButtonText, QColor(220, 220, 220))
+            palette.setColor(QPalette.ColorRole.Highlight, QColor(42, 130, 218))
+            palette.setColor(QPalette.ColorRole.HighlightedText, QColor(255, 255, 255))
+        else:
+            palette = app.style().standardPalette()
+        app.setPalette(palette)
+
+    def apply_font_scale(self, app: QApplication | None = None) -> None:
+        """Scale the application's default font according to settings."""
+
+        app = app or QApplication.instance()
+        if app is None:
+            return
+        default_font = QFont(app.font())
+        if self._base_font_point_size is None:
+            point_size = default_font.pointSizeF()
+            if point_size <= 0:
+                point_size = float(default_font.pointSize())
+            self._base_font_point_size = point_size or 10.0
+        default_font.setPointSizeF(self._base_font_point_size * self._settings.font_scale)
+        app.setFont(default_font)
+
+
+__all__ = ["SettingsService", "UISettings", "DEFAULT_THEME"]
+

--- a/app/ui/__init__.py
+++ b/app/ui/__init__.py
@@ -1,3 +1,5 @@
 """UI components for the DataMiner application."""
 
-__all__: list[str] = []
+from .main_window import MainWindow
+
+__all__ = ["MainWindow"]

--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -1,0 +1,357 @@
+"""Main window for the DataMiner desktop application."""
+
+from __future__ import annotations
+
+import threading
+from functools import partial
+from importlib import metadata
+from typing import Callable
+
+from PyQt6.QtCore import QEasingCurve, QPropertyAnimation, Qt, QTimer
+from PyQt6.QtGui import QAction, QCloseEvent, QKeySequence
+from PyQt6.QtWidgets import (
+    QApplication,
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QListWidget,
+    QMainWindow,
+    QMenu,
+    QMenuBar,
+    QMessageBox,
+    QProgressBar,
+    QPushButton,
+    QShortcut,
+    QSplitter,
+    QStatusBar,
+    QTextBrowser,
+    QTextEdit,
+    QToolBar,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ..services.lmstudio_client import LMStudioClient
+from ..services.progress_service import ProgressService, ProgressUpdate
+from ..services.settings_service import SettingsService
+
+
+class ChatInput(QTextEdit):
+    """Text edit that emits a signal when the user submits a message."""
+
+    def __init__(self, on_send: Callable[[str], None], parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._on_send = on_send
+        self.setPlaceholderText("Type your question...")
+        self.setAcceptRichText(False)
+
+    def keyPressEvent(self, event) -> None:  # type: ignore[override]
+        if event.key() in {Qt.Key.Key_Return, Qt.Key.Key_Enter}:
+            if event.modifiers() & Qt.KeyboardModifier.ShiftModifier:
+                super().keyPressEvent(event)
+                return
+            text = self.toPlainText().strip()
+            if text:
+                self._on_send(text)
+                self.clear()
+            event.accept()
+            return
+        super().keyPressEvent(event)
+
+
+class ToastWidget(QFrame):
+    """Transient toast notification overlay."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent, Qt.WindowType.ToolTip)
+        self.setObjectName("toast")
+        self.setWindowFlag(Qt.WindowType.FramelessWindowHint)
+        self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground, True)
+        self._label = QLabel(self)
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(12, 8, 12, 8)
+        layout.addWidget(self._label)
+        self._animation = QPropertyAnimation(self, b"windowOpacity", self)
+        self._animation.setDuration(250)
+        self._animation.setEasingCurve(QEasingCurve.Type.InOutQuad)
+
+    def show_message(self, message: str, level: str = "info", duration_ms: int = 4000) -> None:
+        palette = self.palette()
+        if level == "error":
+            palette.setColor(palette.ColorRole.Window, Qt.GlobalColor.darkRed)
+            palette.setColor(palette.ColorRole.WindowText, Qt.GlobalColor.white)
+        elif level == "warning":
+            palette.setColor(palette.ColorRole.Window, Qt.GlobalColor.darkYellow)
+            palette.setColor(palette.ColorRole.WindowText, Qt.GlobalColor.black)
+        else:
+            palette.setColor(palette.ColorRole.Window, Qt.GlobalColor.black)
+            palette.setColor(palette.ColorRole.WindowText, Qt.GlobalColor.white)
+        self.setPalette(palette)
+        self.setAutoFillBackground(True)
+        self._label.setText(message)
+        self.adjustSize()
+        parent = self.parentWidget()
+        if parent:
+            margin = 24
+            geo = parent.geometry()
+            self.move(geo.right() - self.width() - margin, geo.top() + margin)
+        self.setWindowOpacity(0.0)
+        self.show()
+        self.raise_()
+        self._animation.stop()
+        self._animation.setStartValue(0.0)
+        self._animation.setEndValue(1.0)
+        self._animation.start()
+        QTimer.singleShot(duration_ms, self._fade_out)
+
+    def _fade_out(self) -> None:
+        self._animation.stop()
+        self._animation.setStartValue(1.0)
+        self._animation.setEndValue(0.0)
+        try:
+            self._animation.finished.disconnect(self.hide)
+        except TypeError:
+            pass
+        self._animation.finished.connect(self.hide)
+        self._animation.start()
+
+
+class MainWindow(QMainWindow):
+    """Primary application window."""
+
+    def __init__(
+        self,
+        *,
+        settings_service: SettingsService,
+        progress_service: ProgressService,
+        lmstudio_client: LMStudioClient,
+        enable_health_monitor: bool = True,
+    ) -> None:
+        super().__init__()
+        self.settings_service = settings_service
+        self.progress_service = progress_service
+        self.lmstudio_client = lmstudio_client
+        self.enable_health_monitor = enable_health_monitor
+        self._setup_window()
+        self._create_actions()
+        self._create_menus_and_toolbar()
+        self._create_status_bar()
+        self._create_layout()
+        self._connect_services()
+        self._toast = ToastWidget(self)
+        self.settings_service.apply_theme()
+        self.settings_service.apply_font_scale()
+        self._update_lmstudio_status()
+        if self.enable_health_monitor:
+            self._health_timer = QTimer(self)
+            self._health_timer.timeout.connect(self._update_lmstudio_status)
+            self._health_timer.start(15000)
+
+    # ------------------------------------------------------------------
+    def _setup_window(self) -> None:
+        self.setWindowTitle("DataMiner")
+        self.resize(1280, 800)
+
+    def _create_actions(self) -> None:
+        self.settings_action = QAction("Settings", self)
+        self.settings_action.triggered.connect(self._open_settings)
+
+        self.help_action = QAction("Help", self)
+        self.help_action.triggered.connect(self._open_help)
+
+        self.toggle_theme_action = QAction("Toggle Theme", self)
+        self.toggle_theme_action.triggered.connect(self.settings_service.toggle_theme)
+
+        self.send_button = QPushButton("Send", self)
+        self.send_button.clicked.connect(self._handle_send)
+
+    def _create_menus_and_toolbar(self) -> None:
+        menubar = QMenuBar(self)
+        self.setMenuBar(menubar)
+
+        file_menu = QMenu("File", self)
+        file_menu.addAction(self.settings_action)
+        menubar.addMenu(file_menu)
+
+        help_menu = QMenu("Help", self)
+        help_menu.addAction(self.help_action)
+        menubar.addMenu(help_menu)
+
+        view_menu = QMenu("View", self)
+        view_menu.addAction(self.toggle_theme_action)
+        menubar.addMenu(view_menu)
+
+        toolbar = QToolBar("Main Toolbar", self)
+        toolbar.addAction(self.settings_action)
+        toolbar.addAction(self.help_action)
+        toolbar.addAction(self.toggle_theme_action)
+        self.addToolBar(toolbar)
+
+    def _create_status_bar(self) -> None:
+        status = QStatusBar(self)
+        self.setStatusBar(status)
+
+        project_label = QLabel(self._project_label_text())
+        status.addWidget(project_label)
+
+        self._lmstudio_indicator = QLabel("LMStudio: Checking...")
+        status.addPermanentWidget(self._lmstudio_indicator)
+
+        self._progress_bar = QProgressBar(self)
+        self._progress_bar.setVisible(False)
+        self._progress_bar.setMaximumWidth(200)
+        status.addPermanentWidget(self._progress_bar)
+
+    def _create_layout(self) -> None:
+        central = QWidget(self)
+        root_layout = QHBoxLayout(central)
+        root_layout.setContentsMargins(0, 0, 0, 0)
+        splitter = QSplitter(Qt.Orientation.Horizontal, central)
+        splitter.setChildrenCollapsible(False)
+        root_layout.addWidget(splitter)
+
+        # Left panel - corpus selector
+        self._corpus_list = QListWidget(splitter)
+        self._corpus_list.setObjectName("corpusSelector")
+        self._corpus_list.addItems(["All Documents", "Recent", "Favorites"])
+        splitter.addWidget(self._corpus_list)
+
+        # Center panel - chat conversation
+        chat_panel = QWidget(splitter)
+        chat_layout = QVBoxLayout(chat_panel)
+        chat_layout.setContentsMargins(8, 8, 8, 8)
+        chat_layout.setSpacing(8)
+        self._chat_log = QTextBrowser(chat_panel)
+        self._chat_log.setObjectName("chatArea")
+        self._chat_log.setOpenLinks(False)
+        self._chat_log.setPlaceholderText("Conversation will appear here.")
+        chat_layout.addWidget(self._chat_log, 1)
+
+        input_container = QFrame(chat_panel)
+        input_layout = QHBoxLayout(input_container)
+        input_layout.setContentsMargins(0, 0, 0, 0)
+        input_layout.setSpacing(6)
+        self._chat_input = ChatInput(self._handle_send, input_container)
+        input_layout.addWidget(self._chat_input, 1)
+        input_layout.addWidget(self.send_button)
+        chat_layout.addWidget(input_container)
+        splitter.addWidget(chat_panel)
+
+        # Right panel - evidence viewer
+        self._evidence_panel = QTextBrowser(splitter)
+        self._evidence_panel.setObjectName("evidencePanel")
+        self._evidence_panel.setPlaceholderText("Evidence and citations will appear here.")
+        splitter.addWidget(self._evidence_panel)
+
+        splitter.setStretchFactor(0, 1)
+        splitter.setStretchFactor(1, 2)
+        splitter.setStretchFactor(2, 1)
+        splitter.setSizes([240, 640, 320])
+
+        self.setCentralWidget(central)
+
+        # Keyboard shortcuts
+        QShortcut(QKeySequence("Ctrl+L"), self, activated=self._focus_corpus)
+        QShortcut(QKeySequence("Ctrl+C"), self, activated=self._copy_chat_text)
+
+    # ------------------------------------------------------------------
+    def _connect_services(self) -> None:
+        self.settings_service.theme_changed.connect(self._apply_theme)
+        self.settings_service.font_scale_changed.connect(self._apply_font_scale)
+        self.progress_service.progress_started.connect(self._on_progress_started)
+        self.progress_service.progress_updated.connect(self._on_progress_updated)
+        self.progress_service.progress_finished.connect(self._on_progress_finished)
+        self.progress_service.toast_requested.connect(self._show_toast)
+
+    # ------------------------------------------------------------------
+    def _handle_send(self, text: str | None = None) -> None:
+        text = text or self._chat_input.toPlainText().strip()
+        if not text:
+            return
+        self._chat_log.append(f"<b>You:</b> {text}")
+        self._chat_input.clear()
+        self.progress_service.start("chat-send", "Sending message...")
+        self.progress_service.notify("Message queued", level="info")
+        QTimer.singleShot(400, lambda: self.progress_service.finish("chat-send", "Message sent"))
+
+    def _focus_corpus(self) -> None:
+        self._corpus_list.setFocus()
+
+    def _copy_chat_text(self) -> None:
+        selected = self._chat_log.textCursor().selectedText()
+        if not selected:
+            selected = self._chat_log.toPlainText()
+        QApplication.clipboard().setText(selected)
+        self.progress_service.notify("Chat copied to clipboard", level="info", duration_ms=2000)
+
+    # ------------------------------------------------------------------
+    def _open_settings(self) -> None:
+        QMessageBox.information(self, "Settings", "Settings dialog coming soon.")
+
+    def _open_help(self) -> None:
+        QMessageBox.information(self, "Help", "Visit the documentation for assistance.")
+
+    # ------------------------------------------------------------------
+    def _apply_theme(self, theme: str) -> None:
+        self.settings_service.apply_theme()
+        self._show_toast(f"Theme set to {theme.title()}.", level="info", duration_ms=1500)
+
+    def _apply_font_scale(self, _scale: float) -> None:
+        self.settings_service.apply_font_scale()
+
+    # ------------------------------------------------------------------
+    def _on_progress_started(self, update: ProgressUpdate) -> None:
+        self._progress_bar.setFormat(update.message or "Working...")
+        self._progress_bar.setRange(0, 0 if update.indeterminate else 100)
+        self._progress_bar.setValue(0 if update.percent is None else int(update.percent))
+        self._progress_bar.setVisible(True)
+
+    def _on_progress_updated(self, update: ProgressUpdate) -> None:
+        if update.message:
+            self._progress_bar.setFormat(update.message)
+        if update.indeterminate:
+            self._progress_bar.setRange(0, 0)
+        elif update.percent is not None:
+            self._progress_bar.setRange(0, 100)
+            self._progress_bar.setValue(int(max(0, min(100, update.percent))))
+
+    def _on_progress_finished(self, update: ProgressUpdate) -> None:
+        if update.message:
+            self.statusBar().showMessage(update.message, 3000)
+        self._progress_bar.setVisible(False)
+
+    def _show_toast(self, message: str, level: str, duration_ms: int) -> None:
+        self._toast.show_message(message, level=level, duration_ms=duration_ms)
+
+    # ------------------------------------------------------------------
+    def _project_label_text(self) -> str:
+        try:
+            version = metadata.version("DataMiner")
+        except metadata.PackageNotFoundError:
+            version = "0.0.0"
+        return f"DataMiner v{version}"
+
+    def _update_lmstudio_status(self) -> None:
+        if not self.enable_health_monitor:
+            self._lmstudio_indicator.setText("LMStudio: Disabled")
+            return
+
+        def worker() -> None:
+            healthy = self.lmstudio_client.health_check()
+            QTimer.singleShot(0, partial(self._set_lmstudio_status, healthy))
+
+        threading.Thread(target=worker, daemon=True).start()
+
+    def _set_lmstudio_status(self, healthy: bool) -> None:
+        text = "LMStudio: Connected" if healthy else "LMStudio: Offline"
+        self._lmstudio_indicator.setText(text)
+
+    # ------------------------------------------------------------------
+    def closeEvent(self, event: QCloseEvent) -> None:  # type: ignore[override]
+        if hasattr(self, "_health_timer"):
+            self._health_timer.stop()
+        return super().closeEvent(event)
+
+
+__all__ = ["MainWindow"]
+

--- a/tests/test_ui_main_window.py
+++ b/tests/test_ui_main_window.py
@@ -1,0 +1,71 @@
+"""UI tests for the DataMiner main window."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+pytest.importorskip("PyQt6", reason="PyQt6 is required for UI tests", exc_type=ImportError)
+pytest.importorskip(
+    "PyQt6.QtWidgets",
+    reason="PyQt6 widgets require a Qt runtime",
+    exc_type=ImportError,
+)
+
+from PyQt6.QtWidgets import QApplication, QSplitter
+
+from app.config import ConfigManager
+from app.services.progress_service import ProgressService
+from app.services.settings_service import SettingsService
+from app.ui.main_window import MainWindow
+from app.services.lmstudio_client import LMStudioClient
+
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+
+@pytest.fixture(scope="session")
+def qt_app() -> QApplication:
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+def build_settings_service(tmp_path, monkeypatch) -> SettingsService:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    manager = ConfigManager(app_name="DataMinerTest", filename="ui.json")
+    return SettingsService(config_manager=manager)
+
+
+def test_main_window_splitter_layout(qt_app, tmp_path, monkeypatch):
+    settings_service = build_settings_service(tmp_path, monkeypatch)
+    progress_service = ProgressService()
+    lmstudio_client = LMStudioClient()
+    window = MainWindow(
+        settings_service=settings_service,
+        progress_service=progress_service,
+        lmstudio_client=lmstudio_client,
+        enable_health_monitor=False,
+    )
+    window.resize(1400, 900)
+    qt_app.processEvents()
+    splitter = window.findChild(QSplitter)
+    assert splitter is not None
+    assert splitter.count() == 3
+    sizes = splitter.sizes()
+    assert sum(sizes) > 0
+    assert sizes[1] >= sizes[0]
+    assert sizes[1] >= sizes[2]
+    window.close()
+
+
+def test_settings_persist_theme_and_font(tmp_path, monkeypatch):
+    settings_service = build_settings_service(tmp_path, monkeypatch)
+    settings_service.set_theme("dark")
+    settings_service.set_font_scale(1.5)
+
+    reloaded = build_settings_service(tmp_path, monkeypatch)
+    assert reloaded.theme == "dark"
+    assert reloaded.font_scale == pytest.approx(1.5)


### PR DESCRIPTION
## Summary
- add a MainWindow built around a horizontal splitter with dedicated corpus, chat, and evidence panes plus menu, toolbar, and keyboard shortcuts
- introduce settings and progress services to persist theme/font preferences and broadcast progress or toast events application-wide
- surface the new window from the application entry point and cover the layout and persistence behaviour with UI-focused pytest coverage

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d3625d48b88322aca9478a5d160ee8