### PR TITLE
Implement rich conversation UI components

### DIFF
--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -12,6 +12,7 @@ from .conversation_manager import (
     ResponseMode,
     SelfCheckResult,
 )
+from .conversation_settings import ConversationSettings
 from .document_hierarchy import DocumentHierarchyService
 from .lmstudio_client import (
     ChatMessage,
@@ -27,6 +28,7 @@ __all__ = [
     "ChatMessage",
     "ConnectionState",
     "ConversationManager",
+    "ConversationSettings",
     "ConversationTurn",
     "PlanItem",
     "ReasoningArtifacts",

--- a/app/services/conversation_manager.py
+++ b/app/services/conversation_manager.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
+from datetime import datetime
 from enum import Enum
 from typing import Any, Literal
 
@@ -112,6 +113,11 @@ class ConversationTurn:
     reasoning: dict[str, Any] | None = None
     reasoning_artifacts: ReasoningArtifacts | None = None
     response_mode: ResponseMode = ResponseMode.GENERATIVE
+    asked_at: datetime | None = None
+    answered_at: datetime | None = None
+    latency_ms: int | None = None
+    token_usage: dict[str, int] | None = None
+    raw_response: dict[str, Any] | None = None
 
     @property
     def reasoning_bullets(self) -> list[str]:
@@ -247,6 +253,7 @@ class ConversationManager:
             reasoning=response.reasoning,
             reasoning_artifacts=artifacts,
             response_mode=response_mode,
+            raw_response=response.raw_response,
         )
         self.turns.append(turn)
         return turn

--- a/app/services/conversation_settings.py
+++ b/app/services/conversation_settings.py
@@ -1,0 +1,85 @@
+"""Reactive conversation settings shared between UI components."""
+
+from __future__ import annotations
+
+from PyQt6.QtCore import QObject, pyqtSignal
+
+from .conversation_manager import ReasoningVerbosity, ResponseMode
+
+
+class ConversationSettings(QObject):
+    """Expose conversation level toggles to coordinate UI and requests."""
+
+    reasoning_verbosity_changed = pyqtSignal(object)
+    show_plan_changed = pyqtSignal(bool)
+    show_assumptions_changed = pyqtSignal(bool)
+    sources_only_mode_changed = pyqtSignal(bool)
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._reasoning_verbosity = ReasoningVerbosity.BRIEF
+        self._show_plan = True
+        self._show_assumptions = True
+        self._sources_only_mode = False
+
+    # ------------------------------------------------------------------
+    @property
+    def reasoning_verbosity(self) -> ReasoningVerbosity:
+        return self._reasoning_verbosity
+
+    def set_reasoning_verbosity(self, verbosity: ReasoningVerbosity) -> None:
+        if not isinstance(verbosity, ReasoningVerbosity):
+            raise TypeError("verbosity must be a ReasoningVerbosity value")
+        if verbosity is self._reasoning_verbosity:
+            return
+        self._reasoning_verbosity = verbosity
+        self.reasoning_verbosity_changed.emit(verbosity)
+
+    # ------------------------------------------------------------------
+    @property
+    def show_plan(self) -> bool:
+        return self._show_plan
+
+    def set_show_plan(self, enabled: bool) -> None:
+        value = bool(enabled)
+        if value == self._show_plan:
+            return
+        self._show_plan = value
+        self.show_plan_changed.emit(value)
+
+    # ------------------------------------------------------------------
+    @property
+    def show_assumptions(self) -> bool:
+        return self._show_assumptions
+
+    def set_show_assumptions(self, enabled: bool) -> None:
+        value = bool(enabled)
+        if value == self._show_assumptions:
+            return
+        self._show_assumptions = value
+        self.show_assumptions_changed.emit(value)
+
+    # ------------------------------------------------------------------
+    @property
+    def sources_only_mode(self) -> bool:
+        return self._sources_only_mode
+
+    def set_sources_only_mode(self, enabled: bool) -> None:
+        value = bool(enabled)
+        if value == self._sources_only_mode:
+            return
+        self._sources_only_mode = value
+        self.sources_only_mode_changed.emit(value)
+
+    # ------------------------------------------------------------------
+    @property
+    def response_mode(self) -> ResponseMode:
+        return (
+            ResponseMode.SOURCES_ONLY
+            if self._sources_only_mode
+            else ResponseMode.GENERATIVE
+        )
+
+
+__all__ = ["ConversationSettings"]
+

--- a/app/ui/__init__.py
+++ b/app/ui/__init__.py
@@ -1,5 +1,7 @@
 """UI components for the DataMiner application."""
 
+from .answer_view import AnswerView
 from .main_window import MainWindow
+from .question_input_widget import QuestionInputWidget
 
-__all__ = ["MainWindow"]
+__all__ = ["AnswerView", "MainWindow", "QuestionInputWidget"]

--- a/app/ui/answer_view.py
+++ b/app/ui/answer_view.py
@@ -1,0 +1,302 @@
+"""Widgets for rendering conversation turns with metadata and actions."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Iterable
+
+from PyQt6.QtCore import Qt
+from PyQt6.QtWidgets import (
+    QApplication,
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QScrollArea,
+    QSizePolicy,
+    QTextBrowser,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ..services.conversation_manager import ConversationTurn
+from ..services.conversation_settings import ConversationSettings
+from ..services.progress_service import ProgressService
+
+
+def _format_timestamp(value: datetime | None) -> str:
+    if value is None:
+        return "—"
+    return value.strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _format_token_usage(token_usage: dict[str, int] | None) -> str:
+    if not token_usage:
+        return "Tokens: —"
+    ordered_keys = ["prompt_tokens", "completion_tokens", "total_tokens"]
+    parts: list[str] = []
+    for key in ordered_keys:
+        if key in token_usage:
+            parts.append(f"{key.replace('_', ' ').title()}: {token_usage[key]}")
+    for key, value in token_usage.items():
+        if key not in ordered_keys:
+            parts.append(f"{key.replace('_', ' ').title()}: {value}")
+    return ", ".join(parts) if parts else "Tokens: —"
+
+
+class TurnCardWidget(QFrame):
+    """Card summarizing a single conversation turn."""
+
+    def __init__(
+        self,
+        turn: ConversationTurn,
+        settings: ConversationSettings,
+        progress_service: ProgressService,
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self.turn = turn
+        self._settings = settings
+        self._progress = progress_service
+        self.setFrameShape(QFrame.Shape.StyledPanel)
+        self.setObjectName("turnCard")
+
+        layout = QVBoxLayout(self)
+        layout.setSpacing(6)
+
+        self.question_label = QLabel(f"Q: {turn.question}", self)
+        self.question_label.setWordWrap(True)
+        self.question_label.setObjectName("turnQuestion")
+        layout.addWidget(self.question_label)
+
+        self.answer_browser = QTextBrowser(self)
+        self.answer_browser.setReadOnly(True)
+        self.answer_browser.setOpenExternalLinks(True)
+        self.answer_browser.setObjectName("turnAnswer")
+        self.answer_browser.setPlainText(turn.answer)
+        self.answer_browser.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.MinimumExpanding)
+        layout.addWidget(self.answer_browser)
+
+        self.metadata_label = QLabel(self)
+        self.metadata_label.setObjectName("turnMetadata")
+        layout.addWidget(self.metadata_label)
+
+        self.citations_label = QLabel(self)
+        self.citations_label.setObjectName("turnCitations")
+        self.citations_label.setWordWrap(True)
+        layout.addWidget(self.citations_label)
+
+        self.reasoning_section = self._create_section("Reasoning summary", [])
+        layout.addWidget(self.reasoning_section)
+
+        self.plan_section = self._create_section("Plan", [])
+        layout.addWidget(self.plan_section)
+
+        self.assumptions_section = self._create_section("Assumptions", [])
+        layout.addWidget(self.assumptions_section)
+
+        self.self_check_section = self._create_section("Self-check", [])
+        layout.addWidget(self.self_check_section)
+
+        actions_row = QHBoxLayout()
+        actions_row.addStretch(1)
+        self.copy_answer_button = QPushButton("Copy answer", self)
+        self.copy_answer_button.clicked.connect(self._copy_answer)
+        actions_row.addWidget(self.copy_answer_button)
+        self.copy_citations_button = QPushButton("Copy citations", self)
+        self.copy_citations_button.clicked.connect(self._copy_citations)
+        actions_row.addWidget(self.copy_citations_button)
+        layout.addLayout(actions_row)
+
+        self._apply_turn_data()
+        self.apply_settings(settings)
+
+    # ------------------------------------------------------------------
+    def _apply_turn_data(self) -> None:
+        turn = self.turn
+        asked = _format_timestamp(turn.asked_at)
+        answered = _format_timestamp(turn.answered_at)
+        latency = f"Latency: {turn.latency_ms} ms" if turn.latency_ms is not None else "Latency: —"
+        tokens = _format_token_usage(turn.token_usage)
+        metadata_text = f"Asked: {asked} | Answered: {answered} | {latency} | {tokens}"
+        self.metadata_label.setText(metadata_text)
+
+        if turn.citations:
+            if all(isinstance(cite, str) for cite in turn.citations):
+                formatted = "\n".join(f"• {cite}" for cite in turn.citations)
+            else:
+                formatted = "\n".join(f"• {str(cite)}" for cite in turn.citations)
+            self.citations_label.setText(f"Citations:\n{formatted}")
+        else:
+            self.citations_label.setText("Citations: —")
+
+        reasoning_bullets = list(turn.reasoning_bullets)
+        self._set_section_content(self.reasoning_section, reasoning_bullets)
+
+        plan_rows: list[str] = []
+        for index, item in enumerate(turn.plan, start=1):
+            status = item.status.replace("_", " ") if item.status else "pending"
+            plan_rows.append(f"{index}. {item.description} [{status}]")
+        self._set_section_content(self.plan_section, plan_rows)
+
+        self._set_section_content(self.assumptions_section, list(turn.assumptions))
+
+        decision = turn.assumption_decision
+        assumptions_extra: list[str] = []
+        if decision:
+            mode = decision.mode.title()
+            rationale = decision.rationale or ""
+            question = decision.clarifying_question or ""
+            parts = [f"Decision: {mode}"]
+            if rationale:
+                parts.append(f"Rationale: {rationale}")
+            if question:
+                parts.append(f"Follow-up: {question}")
+            assumptions_extra.append(" | ".join(parts))
+        if assumptions_extra:
+            current = self.assumptions_section.findChild(QLabel, "contentLabel")
+            if current and current.text():
+                current.setText(current.text() + "\n" + "\n".join(assumptions_extra))
+
+        self_check = turn.self_check
+        self_check_lines: list[str] = []
+        if self_check is not None:
+            status = "Passed" if self_check.passed else "Flagged"
+            self_check_lines.append(f"Status: {status}")
+            if self_check.flags:
+                self_check_lines.extend(f"• {flag}" for flag in self_check.flags)
+            if self_check.notes:
+                self_check_lines.append(self_check.notes)
+        self._set_section_content(self.self_check_section, self_check_lines)
+
+    def apply_settings(self, settings: ConversationSettings) -> None:
+        self._settings = settings
+        self.plan_section.setVisible(settings.show_plan and bool(self.turn.plan))
+        assumptions_visible = settings.show_assumptions and (
+            bool(self.turn.assumptions) or self.turn.assumption_decision is not None
+        )
+        self.assumptions_section.setVisible(assumptions_visible)
+
+    def to_plain_text(self) -> str:
+        parts = [
+            self.question_label.text(),
+            self.answer_browser.toPlainText(),
+            self.metadata_label.text(),
+            self.citations_label.text(),
+        ]
+        for section in (
+            self.reasoning_section,
+            self.plan_section,
+            self.assumptions_section,
+            self.self_check_section,
+        ):
+            label = section.findChild(QLabel, "titleLabel")
+            content = section.findChild(QLabel, "contentLabel")
+            if label and content and section.isVisible() and content.text():
+                parts.append(f"{label.text()}:\n{content.text()}")
+        return "\n".join(filter(None, parts))
+
+    # ------------------------------------------------------------------
+    def _copy_answer(self) -> None:
+        QApplication.clipboard().setText(self.answer_browser.toPlainText())
+        self._progress.notify("Answer copied to clipboard", level="info", duration_ms=1500)
+
+    def _copy_citations(self) -> None:
+        QApplication.clipboard().setText(self.citations_label.text())
+        self._progress.notify("Citations copied", level="info", duration_ms=1500)
+
+    # ------------------------------------------------------------------
+    def _create_section(self, title: str, lines: Iterable[str]) -> QFrame:
+        frame = QFrame(self)
+        frame.setObjectName(f"section_{title.lower().replace(' ', '_')}")
+        layout = QVBoxLayout(frame)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(2)
+        title_label = QLabel(title, frame)
+        title_label.setObjectName("titleLabel")
+        title_label.setStyleSheet("font-weight: 600;")
+        layout.addWidget(title_label)
+        content_label = QLabel("", frame)
+        content_label.setObjectName("contentLabel")
+        content_label.setWordWrap(True)
+        layout.addWidget(content_label)
+        self._set_section_content(frame, list(lines))
+        return frame
+
+    def _set_section_content(self, section: QFrame, lines: Iterable[str]) -> None:
+        label = section.findChild(QLabel, "contentLabel")
+        if label is None:
+            return
+        filtered = [line for line in lines if line]
+        if filtered:
+            label.setText("\n".join(filtered))
+            section.setVisible(True)
+        else:
+            label.clear()
+            section.setVisible(False)
+
+
+class AnswerView(QScrollArea):
+    """Scrollable list of :class:`ConversationTurn` cards."""
+
+    def __init__(
+        self,
+        settings: ConversationSettings,
+        progress_service: ProgressService,
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self._settings = settings
+        self._progress = progress_service
+        self._cards: list[TurnCardWidget] = []
+        self.setWidgetResizable(True)
+        self.setFrameShape(QFrame.Shape.NoFrame)
+
+        container = QWidget(self)
+        self._layout = QVBoxLayout(container)
+        self._layout.setContentsMargins(0, 0, 0, 0)
+        self._layout.setSpacing(8)
+        self._layout.addStretch(1)
+        self.setWidget(container)
+
+        settings.show_plan_changed.connect(self._apply_settings_to_cards)
+        settings.show_assumptions_changed.connect(self._apply_settings_to_cards)
+
+    # ------------------------------------------------------------------
+    @property
+    def cards(self) -> list[TurnCardWidget]:
+        return list(self._cards)
+
+    def clear(self) -> None:
+        for card in self._cards:
+            card.setParent(None)
+        self._cards.clear()
+
+    def render_turns(self, turns: Iterable[ConversationTurn]) -> None:
+        self.clear()
+        for turn in turns:
+            self.add_turn(turn)
+
+    def add_turn(self, turn: ConversationTurn) -> TurnCardWidget:
+        card = TurnCardWidget(turn, self._settings, self._progress, parent=self.widget())
+        self._cards.append(card)
+        self._layout.insertWidget(self._layout.count() - 1, card)
+        self._scroll_to_bottom()
+        return card
+
+    def to_plain_text(self) -> str:
+        return "\n\n".join(card.to_plain_text() for card in self._cards)
+
+    # ------------------------------------------------------------------
+    def _apply_settings_to_cards(self) -> None:
+        for card in self._cards:
+            card.apply_settings(self._settings)
+
+    def _scroll_to_bottom(self) -> None:
+        bar = self.verticalScrollBar()
+        if bar is not None:
+            bar.setValue(bar.maximum())
+
+
+__all__ = ["AnswerView", "TurnCardWidget"]
+

--- a/app/ui/question_input_widget.py
+++ b/app/ui/question_input_widget.py
@@ -1,0 +1,176 @@
+"""Reusable widget housing the chat question input controls."""
+
+from __future__ import annotations
+
+from PyQt6.QtCore import Qt, pyqtSignal
+from PyQt6.QtGui import QFontMetrics
+from PyQt6.QtWidgets import QFrame, QHBoxLayout, QLabel, QPushButton, QTextEdit, QVBoxLayout
+
+
+class _HistoryTextEdit(QTextEdit):
+    """Text edit that surfaces history navigation shortcuts."""
+
+    submit_requested = pyqtSignal()
+    history_previous_requested = pyqtSignal()
+    history_next_requested = pyqtSignal()
+
+    def keyPressEvent(self, event) -> None:  # type: ignore[override]
+        key = event.key()
+        modifiers = event.modifiers()
+        if key in {Qt.Key.Key_Return, Qt.Key.Key_Enter} and (
+            modifiers & Qt.KeyboardModifier.ControlModifier
+        ):
+            event.accept()
+            self.submit_requested.emit()
+            return
+        if key == Qt.Key.Key_Up and modifiers == Qt.KeyboardModifier.NoModifier:
+            if self.textCursor().atStart():
+                event.accept()
+                self.history_previous_requested.emit()
+                return
+        if key == Qt.Key.Key_Down and modifiers == Qt.KeyboardModifier.NoModifier:
+            if self.textCursor().atEnd():
+                event.accept()
+                self.history_next_requested.emit()
+                return
+        super().keyPressEvent(event)
+
+
+class QuestionInputWidget(QFrame):
+    """Composite widget handling question entry, history, and controls."""
+
+    ask_requested = pyqtSignal(str)
+    cleared = pyqtSignal()
+
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent)
+        self.setObjectName("questionInput")
+        self._history: list[str] = []
+        self._history_index = 0
+        self._prerequisites_met = True
+        self._status_message: str | None = None
+        self._busy = False
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(4)
+
+        self.editor = _HistoryTextEdit(self)
+        self.editor.setAcceptRichText(False)
+        self.editor.setPlaceholderText("Ask a question about your data (Ctrl+Enter to send)")
+        self.editor.textChanged.connect(self._update_button_state)
+        self.editor.submit_requested.connect(self._trigger_ask)
+        self.editor.history_previous_requested.connect(self._recall_previous)
+        self.editor.history_next_requested.connect(self._recall_next)
+        layout.addWidget(self.editor, 1)
+
+        buttons_row = QHBoxLayout()
+        buttons_row.setSpacing(6)
+        layout.addLayout(buttons_row)
+
+        self.status_label = QLabel("", self)
+        font = self.status_label.font()
+        font.setPointSizeF(font.pointSizeF() - 1)
+        self.status_label.setFont(font)
+        self.status_label.setStyleSheet("color: palette(dark)")
+        self.status_label.setVisible(False)
+        buttons_row.addWidget(self.status_label, 1)
+
+        self.ask_button = QPushButton("Ask", self)
+        self.ask_button.setDefault(True)
+        self.ask_button.clicked.connect(self._trigger_ask)
+        buttons_row.addWidget(self.ask_button)
+
+        self.clear_button = QPushButton("Clear", self)
+        self.clear_button.clicked.connect(self.clear)
+        buttons_row.addWidget(self.clear_button)
+
+        self._update_button_state()
+
+    # ------------------------------------------------------------------
+    def text(self) -> str:
+        return self.editor.toPlainText().strip()
+
+    def set_text(self, text: str) -> None:
+        self.editor.setPlainText(text)
+        cursor = self.editor.textCursor()
+        cursor.movePosition(cursor.MoveOperation.End)
+        self.editor.setTextCursor(cursor)
+        self._update_button_state()
+
+    def clear(self) -> None:  # type: ignore[override]
+        self.editor.clear()
+        self._history_index = len(self._history)
+        self._update_button_state()
+        self.cleared.emit()
+
+    # ------------------------------------------------------------------
+    def set_busy(self, busy: bool) -> None:
+        self._busy = bool(busy)
+        self.editor.setReadOnly(self._busy)
+        self.editor.setEnabled(not self._busy)
+        self.clear_button.setEnabled(not self._busy)
+        self._update_button_state()
+
+    def set_prerequisites_met(self, ok: bool, message: str | None = None) -> None:
+        self._prerequisites_met = bool(ok)
+        self._status_message = message
+        if self._prerequisites_met or not message:
+            self.status_label.setVisible(False)
+        else:
+            display = message.strip()
+            if display:
+                metrics = QFontMetrics(self.status_label.font())
+                elided = metrics.elidedText(display, Qt.TextElideMode.ElideMiddle, 320)
+                self.status_label.setText(elided)
+                self.status_label.setVisible(True)
+        self._update_button_state()
+
+    # ------------------------------------------------------------------
+    def _trigger_ask(self) -> None:
+        if self._busy:
+            return
+        text = self.text()
+        if not text:
+            return
+        if not self._prerequisites_met:
+            return
+        self._remember_entry(text)
+        self.editor.clear()
+        self.ask_requested.emit(text)
+
+    def _remember_entry(self, text: str) -> None:
+        if text and (not self._history or self._history[-1] != text):
+            self._history.append(text)
+        self._history_index = len(self._history)
+
+    def _recall_previous(self) -> None:
+        if not self._history:
+            return
+        self._history_index = max(0, self._history_index - 1)
+        self._apply_history()
+
+    def _recall_next(self) -> None:
+        if not self._history:
+            return
+        self._history_index = min(len(self._history), self._history_index + 1)
+        self._apply_history()
+
+    def _apply_history(self) -> None:
+        if 0 <= self._history_index < len(self._history):
+            self.set_text(self._history[self._history_index])
+        else:
+            self.editor.clear()
+
+    def _update_button_state(self) -> None:
+        has_text = bool(self.text())
+        enabled = has_text and self._prerequisites_met and not self._busy
+        self.ask_button.setEnabled(enabled)
+        if not self._prerequisites_met and self._status_message:
+            self.ask_button.setToolTip(self._status_message)
+        else:
+            self.ask_button.setToolTip("")
+
+
+__all__ = ["QuestionInputWidget"]
+

--- a/tests/test_ui_main_window.py
+++ b/tests/test_ui_main_window.py
@@ -16,10 +16,11 @@ pytest.importorskip(
 from PyQt6.QtWidgets import QApplication, QSplitter
 
 from app.config import ConfigManager
+from app.services.conversation_manager import ReasoningVerbosity
 from app.services.progress_service import ProgressService
 from app.services.settings_service import SettingsService
 from app.ui.main_window import MainWindow
-from app.services.lmstudio_client import LMStudioClient
+from app.services.lmstudio_client import ChatMessage, LMStudioClient
 
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
@@ -37,6 +38,56 @@ def build_settings_service(tmp_path, monkeypatch) -> SettingsService:
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
     manager = ConfigManager(app_name="DataMinerTest", filename="ui.json")
     return SettingsService(config_manager=manager)
+
+
+class DummyLMStudioClient:
+    """Deterministic LMStudio stub for UI interaction tests."""
+
+    def __init__(self) -> None:
+        self.last_messages: list[dict] = []
+        self.last_options: dict | None = None
+
+    def health_check(self) -> bool:
+        return True
+
+    def chat(self, messages, *, preset, extra_options=None) -> ChatMessage:  # type: ignore[override]
+        self.last_messages = list(messages)
+        self.last_options = extra_options or {}
+        reasoning = {
+            "summary_bullets": ["Reviewed document A for relevant data."],
+            "plan": [
+                {"description": "Search repository", "status": "complete"},
+                {"description": "Summarize findings", "status": "pending"},
+            ],
+            "assumptions": {
+                "used": ["Assumed latest dataset applies"],
+                "decision": "assume",
+                "rationale": "No timeframe specified",
+            },
+            "self_check": {
+                "passed": True,
+                "flags": ["Validated citations"],
+                "notes": "No issues detected",
+            },
+        }
+        metadata = {"citations": ["Doc A"], "reasoning": reasoning}
+        raw_response = {
+            "choices": [
+                {
+                    "message": {
+                        "content": "Deterministic answer",
+                        "metadata": metadata,
+                    }
+                }
+            ],
+            "usage": {"prompt_tokens": 12, "completion_tokens": 24, "total_tokens": 36},
+        }
+        return ChatMessage(
+            content="Deterministic answer",
+            citations=["Doc A"],
+            reasoning=reasoning,
+            raw_response=raw_response,
+        )
 
 
 def test_main_window_splitter_layout(qt_app, tmp_path, monkeypatch):
@@ -69,3 +120,81 @@ def test_settings_persist_theme_and_font(tmp_path, monkeypatch):
     reloaded = build_settings_service(tmp_path, monkeypatch)
     assert reloaded.theme == "dark"
     assert reloaded.font_scale == pytest.approx(1.5)
+
+
+def test_submission_flow_and_controls(qt_app, tmp_path, monkeypatch):
+    settings_service = build_settings_service(tmp_path, monkeypatch)
+    progress_service = ProgressService()
+    client = DummyLMStudioClient()
+    window = MainWindow(
+        settings_service=settings_service,
+        progress_service=progress_service,
+        lmstudio_client=client,
+        enable_health_monitor=False,
+    )
+
+    window.question_input.set_text("What is the latest metric?")
+    window.question_input.ask_button.click()
+    qt_app.processEvents()
+
+    assert len(window.answer_view.cards) == 1
+    first_card = window.answer_view.cards[0]
+    assert first_card.question_label.text().endswith("What is the latest metric?")
+    assert "Deterministic answer" in first_card.answer_browser.toPlainText()
+    assert "Doc A" in first_card.citations_label.text()
+    assert first_card.reasoning_section.isVisible()
+    assert first_card.plan_section.isVisible()
+    assert first_card.assumptions_section.isVisible()
+    assert first_card.self_check_section.isVisible()
+    assert "Latency" in first_card.metadata_label.text()
+    assert "Prompt Tokens" in first_card.metadata_label.text()
+    assert client.last_options is not None
+    reasoning_options = client.last_options.get("reasoning", {})
+    assert reasoning_options.get("verbosity") == ReasoningVerbosity.BRIEF.value
+    assert reasoning_options.get("include_plan") is True
+    assert "Doc A" in window._evidence_panel.toPlainText()
+
+    window._plan_checkbox.setChecked(False)
+    window._assumptions_checkbox.setChecked(False)
+    qt_app.processEvents()
+    assert not first_card.plan_section.isVisible()
+    assert not first_card.assumptions_section.isVisible()
+    window._plan_checkbox.setChecked(True)
+    window._assumptions_checkbox.setChecked(True)
+    qt_app.processEvents()
+
+    minimal_index = window._verbosity_combo.findData(ReasoningVerbosity.MINIMAL)
+    window._verbosity_combo.setCurrentIndex(minimal_index)
+    window.question_input.set_text("Summarize context")
+    window.question_input.ask_button.click()
+    qt_app.processEvents()
+    assert len(window.answer_view.cards) == 2
+    assert client.last_options is not None
+    reasoning_options = client.last_options.get("reasoning", {})
+    assert reasoning_options.get("verbosity") == ReasoningVerbosity.MINIMAL.value
+    assert reasoning_options.get("include_plan") is False
+
+    window._sources_only_checkbox.setChecked(True)
+    window.question_input.set_text("Only sources please")
+    window.question_input.ask_button.click()
+    qt_app.processEvents()
+    assert len(window.answer_view.cards) == 3
+    assert client.last_options is not None
+    assert client.last_options.get("response_mode") == "sources_only"
+
+    latest_card = window.answer_view.cards[-1]
+    latest_card.copy_answer_button.click()
+    qt_app.processEvents()
+    assert QApplication.clipboard().text() == latest_card.answer_browser.toPlainText()
+
+    latest_card.copy_citations_button.click()
+    qt_app.processEvents()
+    assert "Doc A" in QApplication.clipboard().text()
+
+    window._copy_chat_text()
+    qt_app.processEvents()
+    copied_conversation = QApplication.clipboard().text()
+    assert "What is the latest metric?" in copied_conversation
+    assert "Only sources please" in copied_conversation
+
+    window.close()


### PR DESCRIPTION
## Summary
- Added ConversationSettings, QuestionInputWidget, and AnswerView to support advanced conversation controls, history navigation, and rich turn display.
- Refactored MainWindow to integrate new widgets, reasoning toggles, evidence updates, and metadata-aware request handling.
- Expanded UI tests with a deterministic LMStudio stub covering submission flow, control toggles, and clipboard actions.

## Testing
- pytest tests/test_ui_main_window.py *(skipped: PyQt6 not available)*

------
https://chatgpt.com/codex/tasks/task_e_68d36424fe908322a4b7f195a4d8a5b6