### PR TITLE
Add project management, export, and backup workflows

### DIFF
--- a/app/__main__.py
+++ b/app/__main__.py
@@ -7,8 +7,11 @@ import sys
 from PyQt6.QtWidgets import QApplication
 
 from .logging import setup_logging
+from .services.backup_service import BackupService
+from .services.export_service import ExportService
 from .services.lmstudio_client import LMStudioClient
 from .services.progress_service import ProgressService
+from .services.project_service import ProjectService
 from .services.settings_service import SettingsService
 from .ui import MainWindow
 
@@ -24,11 +27,17 @@ def main() -> None:
     settings_service = SettingsService()
     progress_service = ProgressService()
     lmstudio_client = LMStudioClient()
+    project_service = ProjectService()
+    export_service = ExportService()
+    backup_service = BackupService(project_service)
 
     window = MainWindow(
         settings_service=settings_service,
         progress_service=progress_service,
         lmstudio_client=lmstudio_client,
+        project_service=project_service,
+        export_service=export_service,
+        backup_service=backup_service,
     )
     window.show()
 

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -14,6 +14,7 @@ from .conversation_manager import (
 )
 from .conversation_settings import ConversationSettings
 from .document_hierarchy import DocumentHierarchyService
+from .export_service import ExportService
 from .lmstudio_client import (
     ChatMessage,
     LMStudioClient,
@@ -30,6 +31,7 @@ __all__ = [
     "ConversationManager",
     "ConversationSettings",
     "ConversationTurn",
+    "ExportService",
     "PlanItem",
     "ReasoningArtifacts",
     "ReasoningVerbosity",
@@ -57,3 +59,11 @@ except ImportError:  # pragma: no cover
     SettingsService = None  # type: ignore[assignment]
 else:  # pragma: no cover - executed when Qt is available
     __all__.append("SettingsService")
+
+try:  # pragma: no cover - optional dependency guard
+    from .project_service import ProjectRecord, ProjectService
+    from .backup_service import BackupService
+except ImportError:  # pragma: no cover
+    ProjectRecord = ProjectService = BackupService = None  # type: ignore[assignment]
+else:  # pragma: no cover - executed when Qt is available
+    __all__.extend(["ProjectRecord", "ProjectService", "BackupService"])

--- a/app/services/backup_service.py
+++ b/app/services/backup_service.py
@@ -1,0 +1,92 @@
+"""Backup and restore helpers for DataMiner storage."""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import shutil
+import tempfile
+import zipfile
+from pathlib import Path
+
+from .project_service import ProjectService
+from ..storage.database import SCHEMA_VERSION
+
+
+MANIFEST_NAME = "manifest.json"
+
+
+class BackupService:
+    """Create and restore archive snapshots of application data."""
+
+    def __init__(self, project_service: ProjectService) -> None:
+        self._projects = project_service
+
+    def create_backup(self, destination: str | Path) -> Path:
+        destination_path = Path(destination)
+        if destination_path.is_dir():
+            timestamp = _dt.datetime.now(_dt.UTC).strftime("%Y%m%d-%H%M%S")
+            destination_path = destination_path / f"dataminer-backup-{timestamp}.zip"
+        if not destination_path.parent.exists():
+            destination_path.parent.mkdir(parents=True, exist_ok=True)
+
+        manifest = {
+            "created": _dt.datetime.now(_dt.UTC).isoformat().replace("+00:00", "Z"),
+            "schema_version": SCHEMA_VERSION,
+            "active_project": self._projects.active_project_id,
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            db_export = tmp_path / "database.db"
+            self._projects.database_manager.export_database(db_export)
+            manifest_path = tmp_path / MANIFEST_NAME
+            manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+            derived_root = self._projects.storage_root / "projects"
+
+            with zipfile.ZipFile(destination_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+                archive.write(db_export, "database/dataminer.db")
+                if derived_root.exists():
+                    for path in derived_root.rglob("*"):
+                        if path.is_file():
+                            arcname = Path("derived") / path.relative_to(self._projects.storage_root)
+                            archive.write(path, arcname)
+                archive.write(manifest_path, MANIFEST_NAME)
+        return destination_path
+
+    def restore_backup(self, archive_path: str | Path) -> None:
+        archive = Path(archive_path)
+        if not archive.exists():
+            raise FileNotFoundError(archive)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            with zipfile.ZipFile(archive, "r") as zip_file:
+                zip_file.extractall(tmp_path)
+            manifest_path = tmp_path / MANIFEST_NAME
+            if not manifest_path.exists():
+                raise ValueError("Backup archive missing manifest.json")
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            schema_version = int(manifest.get("schema_version", 0))
+            if schema_version > SCHEMA_VERSION:
+                raise ValueError("Backup schema version is newer than supported")
+
+            database_source = tmp_path / "database" / "dataminer.db"
+            if not database_source.exists():
+                raise ValueError("Backup archive missing database snapshot")
+            self._projects.database_manager.import_database(database_source)
+
+            derived_source = tmp_path / "derived" / "projects"
+            target_root = self._projects.storage_root / "projects"
+            if target_root.exists():
+                shutil.rmtree(target_root)
+            if derived_source.exists():
+                shutil.copytree(derived_source, target_root)
+            else:
+                target_root.mkdir(parents=True, exist_ok=True)
+
+        self._projects.reload()
+
+
+__all__ = ["BackupService", "MANIFEST_NAME"]
+

--- a/app/services/export_service.py
+++ b/app/services/export_service.py
@@ -1,0 +1,322 @@
+"""Utilities for exporting conversations and snippets to various formats."""
+
+from __future__ import annotations
+
+import datetime as _dt
+import html
+import json
+import textwrap
+from pathlib import Path
+from typing import Iterable, Sequence
+
+from .conversation_manager import ConversationTurn
+
+
+class ExportService:
+    """Render conversation history or snippets to export-friendly formats."""
+
+    def conversation_to_markdown(
+        self,
+        turns: Sequence[ConversationTurn] | Iterable[ConversationTurn],
+        *,
+        title: str = "Conversation Export",
+        metadata: dict | None = None,
+    ) -> str:
+        entries = list(turns)
+        lines: list[str] = [f"# {title}", ""]
+        timestamp = _dt.datetime.now(_dt.UTC).strftime("%Y-%m-%d %H:%M:%SZ")
+        lines.append(f"_Generated: {timestamp}_")
+        if metadata:
+            lines.append("")
+            for key, value in metadata.items():
+                lines.append(f"* **{key}**: {value}")
+        for index, turn in enumerate(entries, start=1):
+            lines.extend(self._turn_to_markdown(turn, index))
+        return "\n".join(lines).strip() + "\n"
+
+    def conversation_to_html(
+        self,
+        turns: Sequence[ConversationTurn] | Iterable[ConversationTurn],
+        *,
+        title: str = "Conversation Export",
+        metadata: dict | None = None,
+    ) -> str:
+        entries = list(turns)
+        timestamp = _dt.datetime.now(_dt.UTC).strftime("%Y-%m-%d %H:%M:%SZ")
+        head = textwrap.dedent(
+            f"""
+            <!DOCTYPE html>
+            <html lang=\"en\">
+              <head>
+                <meta charset=\"utf-8\" />
+                <title>{html.escape(title)}</title>
+                <style>
+                  body {{ font-family: Arial, sans-serif; margin: 1.5em; }}
+                  h1 {{ border-bottom: 1px solid #999; padding-bottom: 0.3em; }}
+                  h2 {{ margin-top: 1.4em; }}
+                  .meta {{ color: #555; margin-bottom: 1em; }}
+                  .section {{ margin-top: 0.8em; }}
+                  .section h3 {{ margin-bottom: 0.3em; }}
+                  .citations li {{ margin-bottom: 0.2em; }}
+                  pre {{ background: #f6f6f6; padding: 0.6em; overflow-x: auto; }}
+                </style>
+              </head>
+              <body>
+            """
+        ).strip("\n")
+        parts: list[str] = [head, f"<h1>{html.escape(title)}</h1>"]
+        parts.append(f"<div class='meta'><strong>Generated:</strong> {timestamp}</div>")
+        if metadata:
+            items = "".join(
+                f"<li><strong>{html.escape(str(key))}:</strong> {html.escape(str(value))}</li>"
+                for key, value in metadata.items()
+            )
+            parts.append(f"<ul class='meta'>{items}</ul>")
+        for index, turn in enumerate(entries, start=1):
+            parts.append(self._turn_to_html(turn, index))
+        parts.append("  </body>\n</html>")
+        return "\n".join(parts)
+
+    def snippets_to_text(self, snippets: Iterable[dict | str]) -> str:
+        lines: list[str] = []
+        for snippet in snippets:
+            if isinstance(snippet, str):
+                text = snippet
+            elif isinstance(snippet, dict):
+                label = snippet.get("label") or snippet.get("source") or "Snippet"
+                content = snippet.get("snippet_html") or snippet.get("snippet") or ""
+                text = f"{label}:\n{self._strip_html(content)}"
+                metadata = snippet.get("metadata_text") or snippet.get("metadata")
+                if metadata:
+                    text += f"\n{metadata}"
+            else:
+                text = str(snippet)
+            lines.append(text.strip())
+        return "\n\n".join(line for line in lines if line)
+
+    def write_text(self, destination: str | Path, content: str) -> Path:
+        path = Path(destination)
+        if not path.parent.exists():
+            path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+        return path
+
+    def export_conversation_markdown(
+        self,
+        destination: str | Path,
+        turns: Sequence[ConversationTurn] | Iterable[ConversationTurn],
+        *,
+        title: str = "Conversation Export",
+        metadata: dict | None = None,
+    ) -> Path:
+        content = self.conversation_to_markdown(turns, title=title, metadata=metadata)
+        return self.write_text(destination, content)
+
+    def export_conversation_html(
+        self,
+        destination: str | Path,
+        turns: Sequence[ConversationTurn] | Iterable[ConversationTurn],
+        *,
+        title: str = "Conversation Export",
+        metadata: dict | None = None,
+    ) -> Path:
+        content = self.conversation_to_html(turns, title=title, metadata=metadata)
+        return self.write_text(destination, content)
+
+    def export_snippets_text(
+        self, destination: str | Path, snippets: Iterable[dict | str]
+    ) -> Path:
+        content = self.snippets_to_text(snippets)
+        return self.write_text(destination, content)
+
+    # ------------------------------------------------------------------
+    def _turn_to_markdown(self, turn: ConversationTurn, index: int) -> list[str]:
+        asked = turn.asked_at.isoformat() if turn.asked_at else "—"
+        answered = turn.answered_at.isoformat() if turn.answered_at else "—"
+        latency = f"{turn.latency_ms} ms" if turn.latency_ms is not None else "—"
+        token_json = json.dumps(turn.token_usage or {}, indent=2, sort_keys=True)
+        lines = [
+            "",
+            f"## Turn {index}",
+            "",
+            f"**Question:** {turn.question.strip() if turn.question else '—'}",
+            "",
+            "**Answer:**",
+            "",
+            textwrap.indent((turn.answer or "—").strip(), "> "),
+            "",
+            f"*Asked:* {asked}  ",
+            f"*Answered:* {answered}  ",
+            f"*Latency:* {latency}",
+            "",
+            "### Citations",
+        ]
+        if turn.citations:
+            for idx, citation in enumerate(turn.citations, start=1):
+                lines.append(f"{idx}. {self._format_citation_text(citation)}")
+        else:
+            lines.append("No citations available.")
+        reasoning = self._format_reasoning_markdown(turn)
+        if reasoning:
+            lines.extend(reasoning)
+        lines.append("### Token Usage")
+        lines.extend(textwrap.indent(token_json or "{}", "    ").splitlines())
+        return lines
+
+    def _turn_to_html(self, turn: ConversationTurn, index: int) -> str:
+        asked = html.escape(turn.asked_at.isoformat()) if turn.asked_at else "—"
+        answered = html.escape(turn.answered_at.isoformat()) if turn.answered_at else "—"
+        latency = f"{turn.latency_ms} ms" if turn.latency_ms is not None else "—"
+        answer = html.escape(turn.answer or "—").replace("\n", "<br/>")
+        question = html.escape(turn.question or "—")
+        citations = "".join(
+            f"<li>{html.escape(self._format_citation_text(citation))}</li>"
+            for citation in turn.citations or []
+        )
+        if not citations:
+            citations = "<li>No citations available.</li>"
+        reasoning = self._format_reasoning_html(turn)
+        token_json = html.escape(json.dumps(turn.token_usage or {}, indent=2, sort_keys=True))
+        sections = [
+            f"<h2>Turn {index}</h2>",
+            f"<div class='section'><h3>Question</h3><p>{question}</p></div>",
+            f"<div class='section'><h3>Answer</h3><p>{answer}</p></div>",
+            f"<div class='meta'>Asked: {asked} &nbsp;|&nbsp; Answered: {answered} &nbsp;|&nbsp; Latency: {latency}</div>",
+            f"<div class='section'><h3>Citations</h3><ul class='citations'>{citations}</ul></div>",
+        ]
+        if reasoning:
+            sections.append(reasoning)
+        sections.append(
+            f"<div class='section'><h3>Token Usage</h3><pre>{token_json}</pre></div>"
+        )
+        return "\n".join(sections)
+
+    def _format_reasoning_markdown(self, turn: ConversationTurn) -> list[str]:
+        lines: list[str] = []
+        if turn.reasoning_bullets:
+            lines.extend(["", "### Reasoning", ""])
+            for bullet in turn.reasoning_bullets:
+                lines.append(f"- {bullet}")
+        if turn.plan:
+            lines.extend(["", "### Plan", ""])
+            for idx, item in enumerate(turn.plan, start=1):
+                status = item.status.replace("_", " ") if item.status else "pending"
+                lines.append(f"{idx}. {item.description} [{status}]")
+        if turn.assumptions or turn.assumption_decision is not None:
+            lines.extend(["", "### Assumptions", ""])
+            for assumption in turn.assumptions:
+                lines.append(f"- {assumption}")
+            decision = turn.assumption_decision
+            if decision:
+                detail = [f"Decision: {decision.mode.title()}"]
+                if decision.rationale:
+                    detail.append(f"Rationale: {decision.rationale}")
+                if decision.clarifying_question:
+                    detail.append(f"Follow-up: {decision.clarifying_question}")
+                lines.append("- " + " | ".join(detail))
+        if turn.self_check is not None:
+            self_check = turn.self_check
+            lines.extend(["", "### Self-check", ""])
+            lines.append("- Status: " + ("Passed" if self_check.passed else "Flagged"))
+            for flag in self_check.flags:
+                lines.append(f"- Flag: {flag}")
+            if self_check.notes:
+                lines.append(f"- Notes: {self_check.notes}")
+        return lines
+
+    def _format_reasoning_html(self, turn: ConversationTurn) -> str:
+        sections: list[str] = []
+        if turn.reasoning_bullets:
+            bullets = "".join(f"<li>{html.escape(item)}</li>" for item in turn.reasoning_bullets)
+            sections.append(
+                f"<div class='section'><h3>Reasoning</h3><ul>{bullets}</ul></div>"
+            )
+        if turn.plan:
+            items = "".join(
+                f"<li>{html.escape(item.description)} <em>[{html.escape(item.status or 'pending')}]</em></li>"
+                for item in turn.plan
+            )
+            sections.append(f"<div class='section'><h3>Plan</h3><ol>{items}</ol></div>")
+        if turn.assumptions or turn.assumption_decision is not None:
+            assumptions = "".join(
+                f"<li>{html.escape(text)}</li>" for text in turn.assumptions
+            )
+            extras: list[str] = []
+            decision = turn.assumption_decision
+            if decision:
+                detail = [f"Decision: {decision.mode.title()}"]
+                if decision.rationale:
+                    detail.append(f"Rationale: {decision.rationale}")
+                if decision.clarifying_question:
+                    detail.append(f"Follow-up: {decision.clarifying_question}")
+                extras.append(" | ".join(html.escape(part) for part in detail))
+            if extras:
+                assumptions += "".join(f"<li>{extra}</li>" for extra in extras)
+            sections.append(f"<div class='section'><h3>Assumptions</h3><ul>{assumptions or '<li>None</li>'}</ul></div>")
+        if turn.self_check is not None:
+            self_check = turn.self_check
+            flags = "".join(f"<li>{html.escape(flag)}</li>" for flag in self_check.flags)
+            extra = f"<p>Notes: {html.escape(self_check.notes)}</p>" if self_check.notes else ""
+            sections.append(
+                "".join(
+                    [
+                        "<div class='section'><h3>Self-check</h3>",
+                        f"<p>Status: {'Passed' if self_check.passed else 'Flagged'}</p>",
+                        f"<ul>{flags}</ul>" if flags else "",
+                        extra,
+                        "</div>",
+                    ]
+                )
+            )
+        return "".join(sections)
+
+    @staticmethod
+    def _format_citation_text(citation: object) -> str:
+        if isinstance(citation, str):
+            return citation
+        if isinstance(citation, dict):
+            source = citation.get("source") or citation.get("title") or citation.get("path")
+            location: list[str] = []
+            page = citation.get("page")
+            section = citation.get("section")
+            if page is not None:
+                location.append(f"page {page}")
+            if section:
+                location.append(str(section))
+            snippet = citation.get("snippet")
+            label = source or "Reference"
+            tail = f" ({', '.join(location)})" if location else ""
+            if snippet:
+                snippet_text = ExportService._strip_html(snippet)
+                return f"{label}{tail}: {snippet_text}"
+            return f"{label}{tail}".strip()
+        return str(citation)
+
+    @staticmethod
+    def _strip_html(value: str | None) -> str:
+        if not value:
+            return ""
+        cleaned = value.replace("<br>", "\n").replace("<br/>", "\n")
+        result: list[str] = []
+        in_tag = False
+        buffer: list[str] = []
+        for char in cleaned:
+            if char == "<":
+                in_tag = True
+                if buffer:
+                    result.append("".join(buffer))
+                    buffer.clear()
+                continue
+            if char == ">":
+                in_tag = False
+                continue
+            if not in_tag:
+                buffer.append(char)
+        if buffer:
+            result.append("".join(buffer))
+        text = html.unescape("".join(result))
+        return " ".join(text.split())
+
+
+__all__ = ["ExportService"]
+

--- a/app/services/project_service.py
+++ b/app/services/project_service.py
@@ -1,0 +1,323 @@
+"""Project management utilities for coordinating application state."""
+
+from __future__ import annotations
+
+import shutil
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from PyQt6.QtCore import QObject, pyqtSignal
+
+from ..config import ConfigManager, get_user_config_dir
+from ..storage import (
+    BackgroundTaskLogRepository,
+    ChatRepository,
+    DatabaseManager,
+    DocumentRepository,
+    IngestDocumentRepository,
+    ProjectRepository,
+)
+
+
+DEFAULT_PROJECT_NAME = "Default Project"
+
+
+@dataclass(slots=True)
+class ProjectRecord:
+    """Lightweight representation of a stored project."""
+
+    id: int
+    name: str
+    description: str | None = None
+
+
+class ProjectService(QObject):
+    """Coordinate project state, storage paths, and per-project settings."""
+
+    projects_changed = pyqtSignal(object)
+    active_project_changed = pyqtSignal(object)
+
+    def __init__(
+        self,
+        *,
+        storage_root: str | Path | None = None,
+        config_manager: ConfigManager | None = None,
+    ) -> None:
+        super().__init__()
+        self._config = config_manager or ConfigManager()
+        if storage_root is None:
+            storage_root = get_user_config_dir() / "storage"
+        self._storage_root = Path(storage_root)
+        self._storage_root.mkdir(parents=True, exist_ok=True)
+        self._db_path = self._storage_root / "dataminer.db"
+        self._db = DatabaseManager(self._db_path)
+        self._db.initialize()
+        self.projects = ProjectRepository(self._db)
+        self.documents = DocumentRepository(self._db)
+        self.chats = ChatRepository(self._db)
+        self.ingest = IngestDocumentRepository(self._db)
+        self.background_tasks = BackgroundTaskLogRepository(self._db)
+        self._lock = threading.RLock()
+        self._active_project_id: int | None = None
+        self._ensure_default_project()
+        self._load_active_project()
+
+    # ------------------------------------------------------------------
+    # Lifecycle helpers
+    def shutdown(self) -> None:
+        """Close resources held by the service."""
+
+        with self._lock:
+            self._db.close()
+
+    # ------------------------------------------------------------------
+    @property
+    def storage_root(self) -> Path:
+        return self._storage_root
+
+    @property
+    def database_path(self) -> Path:
+        return self._db_path
+
+    @property
+    def database_manager(self) -> DatabaseManager:
+        return self._db
+
+    @property
+    def active_project_id(self) -> int:
+        if self._active_project_id is None:
+            raise RuntimeError("Active project not initialised")
+        return self._active_project_id
+
+    def active_project(self) -> ProjectRecord:
+        record = self.get_project(self.active_project_id)
+        if record is None:
+            raise RuntimeError("Active project record missing")
+        return record
+
+    # ------------------------------------------------------------------
+    def list_projects(self) -> list[ProjectRecord]:
+        records: list[ProjectRecord] = []
+        for entry in self.projects.list():
+            if not entry:
+                continue
+            records.append(
+                ProjectRecord(
+                    id=int(entry["id"]),
+                    name=str(entry.get("name", "")),
+                    description=entry.get("description"),
+                )
+            )
+        return records
+
+    def get_project(self, project_id: int) -> ProjectRecord | None:
+        entry = self.projects.get(project_id)
+        if not entry:
+            return None
+        return ProjectRecord(
+            id=int(entry["id"]),
+            name=str(entry.get("name", "")),
+            description=entry.get("description"),
+        )
+
+    def create_project(
+        self, name: str, *, description: str | None = None, activate: bool = True
+    ) -> ProjectRecord:
+        with self._lock:
+            created = self.projects.create(name, description=description)
+            project = ProjectRecord(
+                id=int(created["id"]),
+                name=str(created.get("name", name)),
+                description=created.get("description"),
+            )
+            self._ensure_project_storage(project.id)
+            self._emit_projects_changed()
+            if activate:
+                self.set_active_project(project.id)
+            return project
+
+    def rename_project(
+        self, project_id: int, *, name: str | None = None, description: str | None = None
+    ) -> ProjectRecord:
+        updates: dict[str, Any] = {}
+        if name is not None:
+            updates["name"] = name
+        if description is not None:
+            updates["description"] = description
+        if not updates:
+            record = self.get_project(project_id)
+            if record is None:
+                raise LookupError(f"Unknown project id {project_id}")
+            return record
+        with self._lock:
+            updated = self.projects.update(project_id, **updates)
+            if not updated:
+                raise LookupError(f"Unknown project id {project_id}")
+            record = ProjectRecord(
+                id=int(updated["id"]),
+                name=str(updated.get("name", "")),
+                description=updated.get("description"),
+            )
+            self._emit_projects_changed()
+            if project_id == self._active_project_id:
+                self._emit_active_project_changed(record)
+            return record
+
+    def delete_project(self, project_id: int) -> None:
+        with self._lock:
+            if project_id == self._active_project_id:
+                raise RuntimeError("Cannot delete the active project")
+            self.projects.delete(project_id)
+            storage = self._project_storage_dir(project_id)
+            if storage.exists():
+                shutil.rmtree(storage, ignore_errors=True)
+            self._remove_project_settings(project_id)
+            self._emit_projects_changed()
+
+    def set_active_project(self, project_id: int) -> None:
+        project = self.get_project(project_id)
+        if project is None:
+            raise LookupError(f"Unknown project id {project_id}")
+        with self._lock:
+            self._active_project_id = project_id
+            self._ensure_project_storage(project_id)
+            self._store_active_project(project_id)
+            self._emit_active_project_changed(project)
+
+    def reload(self) -> None:
+        """Reload persisted state after an external change such as restore."""
+
+        with self._lock:
+            self._db.close()
+            self._db = DatabaseManager(self._db_path)
+            self._db.initialize()
+            self.projects = ProjectRepository(self._db)
+            self.documents = DocumentRepository(self._db)
+            self.chats = ChatRepository(self._db)
+            self.ingest = IngestDocumentRepository(self._db)
+            self.background_tasks = BackgroundTaskLogRepository(self._db)
+            self._ensure_default_project()
+            self._load_active_project()
+            self._emit_projects_changed()
+            self._emit_active_project_changed(self.active_project())
+
+    # ------------------------------------------------------------------
+    # Storage helpers
+    def get_project_storage(self, project_id: int) -> Path:
+        return self._project_storage_dir(project_id)
+
+    def purge_project_data(self, project_id: int) -> None:
+        """Remove derived data for ``project_id`` without deleting source files."""
+
+        with self._lock:
+            with self._db.transaction() as connection:
+                connection.execute("DELETE FROM documents WHERE project_id = ?", (project_id,))
+                connection.execute("DELETE FROM chats WHERE project_id = ?", (project_id,))
+                connection.execute("DELETE FROM tags WHERE project_id = ?", (project_id,))
+            storage = self._project_storage_dir(project_id)
+            if storage.exists():
+                shutil.rmtree(storage, ignore_errors=True)
+            self._ensure_project_storage(project_id)
+
+    # ------------------------------------------------------------------
+    # Conversation setting helpers
+    def load_conversation_settings(self, project_id: int) -> dict[str, Any]:
+        data = self._config.load()
+        projects = data.get("projects") if isinstance(data, dict) else {}
+        if not isinstance(projects, dict):
+            return {}
+        settings = projects.get("conversation")
+        if not isinstance(settings, dict):
+            return {}
+        record = settings.get(str(project_id), {})
+        return record if isinstance(record, dict) else {}
+
+    def save_conversation_settings(self, project_id: int, settings: dict[str, Any]) -> None:
+        data = self._config.load()
+        if not isinstance(data, dict):
+            data = {}
+        projects = data.setdefault("projects", {})
+        if not isinstance(projects, dict):
+            projects = {}
+            data["projects"] = projects
+        conversation = projects.setdefault("conversation", {})
+        if not isinstance(conversation, dict):
+            conversation = {}
+            projects["conversation"] = conversation
+        conversation[str(project_id)] = settings
+        self._config.save(data)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    def _ensure_default_project(self) -> None:
+        if self.projects.list():
+            return
+        created = self.projects.create(DEFAULT_PROJECT_NAME)
+        self._ensure_project_storage(int(created["id"]))
+        self._store_active_project(int(created["id"]))
+
+    def _load_active_project(self) -> None:
+        stored = self._load_active_project_id()
+        available = {record.id for record in self.list_projects()}
+        if stored in available:
+            self._active_project_id = stored
+        elif available:
+            self._active_project_id = sorted(available)[0]
+        else:
+            raise RuntimeError("No projects available")
+        self._ensure_project_storage(self._active_project_id)
+
+    def _load_active_project_id(self) -> int | None:
+        data = self._config.load()
+        if not isinstance(data, dict):
+            return None
+        projects = data.get("projects")
+        if not isinstance(projects, dict):
+            return None
+        value = projects.get("active_id")
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    def _store_active_project(self, project_id: int) -> None:
+        data = self._config.load()
+        if not isinstance(data, dict):
+            data = {}
+        projects = data.setdefault("projects", {})
+        if not isinstance(projects, dict):
+            projects = {}
+            data["projects"] = projects
+        projects["active_id"] = project_id
+        self._config.save(data)
+
+    def _remove_project_settings(self, project_id: int) -> None:
+        data = self._config.load()
+        if not isinstance(data, dict):
+            return
+        projects = data.get("projects")
+        if not isinstance(projects, dict):
+            return
+        conversation = projects.get("conversation")
+        if isinstance(conversation, dict) and str(project_id) in conversation:
+            conversation.pop(str(project_id), None)
+            self._config.save(data)
+
+    def _project_storage_dir(self, project_id: int) -> Path:
+        return self._storage_root / "projects" / str(project_id)
+
+    def _ensure_project_storage(self, project_id: int) -> None:
+        storage = self._project_storage_dir(project_id)
+        storage.mkdir(parents=True, exist_ok=True)
+
+    def _emit_projects_changed(self) -> None:
+        self.projects_changed.emit(self.list_projects())
+
+    def _emit_active_project_changed(self, project: ProjectRecord) -> None:
+        self.active_project_changed.emit(project)
+
+
+__all__ = ["ProjectService", "ProjectRecord", "DEFAULT_PROJECT_NAME"]
+

--- a/app/ui/evidence_panel.py
+++ b/app/ui/evidence_panel.py
@@ -183,6 +183,15 @@ class EvidencePanel(QWidget):
         row = self._list.currentRow()
         return row if row >= 0 else None
 
+    def selected_record(self) -> EvidenceRecord | None:
+        index = self.selected_index
+        if index is None:
+            return None
+        try:
+            return self._records[index]
+        except IndexError:  # pragma: no cover - defensive guard
+            return None
+
     @property
     def current_scope(self) -> dict[str, list[str]]:
         include = [record.identifier for record in self._records if record.state == "include"]

--- a/tests/test_export_and_backup.py
+++ b/tests/test_export_and_backup.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from datetime import datetime
+import shutil
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import pytest
+
+from app.config import ConfigManager
+from app.services.backup_service import BackupService
+from app.services.conversation_manager import (
+    AssumptionDecision,
+    ConversationTurn,
+    PlanItem,
+    ReasoningArtifacts,
+    SelfCheckResult,
+)
+from app.services.export_service import ExportService
+from app.services.project_service import ProjectService
+
+
+def build_project_service(tmp_path: Path) -> ProjectService:
+    config = ConfigManager(app_name="DataMinerTest", filename="projects.json")
+    service = ProjectService(storage_root=tmp_path / "storage", config_manager=config)
+    return service
+
+
+def test_export_service_includes_reasoning_and_citations() -> None:
+    export = ExportService()
+    artifacts = ReasoningArtifacts(
+        summary_bullets=["Reviewed primary source"],
+        plan_items=[PlanItem(description="Check tables", status="complete")],
+        assumptions=["Assumed latest revision"],
+        assumption_decision=AssumptionDecision(
+            mode="assume", rationale="No conflicting versions"
+        ),
+        self_check=SelfCheckResult(passed=True, flags=["Verified citations"], notes="All good"),
+    )
+    turn = ConversationTurn(
+        question="What is the outcome?",
+        answer="Outcome is 42 [1].",
+        citations=[{"source": "Doc A", "snippet": "<mark>42</mark> is the result", "page": 3}],
+        reasoning_artifacts=artifacts,
+        asked_at=datetime(2024, 1, 1, 12, 0, 0),
+        answered_at=datetime(2024, 1, 1, 12, 0, 5),
+        latency_ms=5000,
+        token_usage={"prompt_tokens": 10, "completion_tokens": 15},
+    )
+
+    markdown = export.conversation_to_markdown([turn], metadata={"Project": "Demo"})
+    assert "Reasoning" in markdown
+    assert "Doc A" in markdown
+    assert "Plan" in markdown
+    assert "Token Usage" in markdown
+
+    html = export.conversation_to_html([turn], metadata={"Project": "Demo"})
+    assert "<h2>Turn 1</h2>" in html
+    assert "Doc A" in html
+    assert "Reasoning" in html
+    assert "Self-check" in html
+
+
+def test_project_service_lifecycle_and_settings(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    service = build_project_service(tmp_path)
+    try:
+        default_project = service.active_project()
+        service.save_conversation_settings(default_project.id, {"show_plan": False})
+
+        created = service.create_project("Analysis", activate=True)
+        service.save_conversation_settings(created.id, {"show_plan": True, "sources_only": True})
+
+        service.set_active_project(default_project.id)
+        original_settings = service.load_conversation_settings(default_project.id)
+        assert original_settings.get("show_plan") is False
+
+        service.set_active_project(created.id)
+        created_settings = service.load_conversation_settings(created.id)
+        assert created_settings.get("show_plan") is True
+        assert created_settings.get("sources_only") is True
+
+        storage_path = service.get_project_storage(created.id)
+        assert storage_path.exists()
+
+        service.set_active_project(default_project.id)
+        service.delete_project(created.id)
+        remaining_ids = {record.id for record in service.list_projects()}
+        assert created.id not in remaining_ids
+    finally:
+        service.shutdown()
+
+
+def test_backup_restore_persists_audit_trail(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    service = build_project_service(tmp_path)
+    backup = BackupService(service)
+    try:
+        project = service.active_project()
+        log = service.background_tasks.create(
+            "ingest", status="running", message="Started"
+        )
+        storage_dir = service.get_project_storage(project.id)
+        cache_file = storage_dir / "cache" / "data.txt"
+        cache_file.parent.mkdir(parents=True, exist_ok=True)
+        cache_file.write_text("cached", encoding="utf-8")
+
+        archive = backup.create_backup(tmp_path)
+
+        with service.database_manager.transaction() as connection:
+            connection.execute("DELETE FROM background_task_logs")
+        shutil.rmtree(storage_dir)
+
+        backup.restore_backup(archive)
+
+        restored = service.background_tasks.get(log["id"])
+        assert restored is not None
+        assert restored["status"] == "running"
+        assert (service.get_project_storage(project.id) / "cache" / "data.txt").exists()
+    finally:
+        service.shutdown()


### PR DESCRIPTION
## Summary
- implement a ProjectService to isolate per-project storage, settings, and lifecycle with UI coordination
- add ExportService and BackupService plus toolbar/menu actions for conversation exports, snippet text output, and archive restore
- extend the main window with project switching controls, storage management actions, and integrate the new services throughout the UI
- add acceptance coverage for export formats, project lifecycle behavior, and backup/restore of audit trail data

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d36b2f5ba88322b899198a806dcb16