### PR TITLE
Fix QShortcut import for PyQt6

### DIFF
--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -10,7 +10,7 @@ import threading
 from typing import Any
 
 from PyQt6.QtCore import QEasingCurve, QPropertyAnimation, Qt, QTimer, QUrl
-from PyQt6.QtGui import QAction, QCloseEvent, QDesktopServices, QKeySequence
+from PyQt6.QtGui import QAction, QCloseEvent, QDesktopServices, QKeySequence, QShortcut
 from PyQt6.QtWidgets import (
     QApplication,
     QCheckBox,
@@ -27,7 +27,6 @@ from PyQt6.QtWidgets import (
     QMenuBar,
     QMessageBox,
     QProgressBar,
-    QShortcut,
     QSplitter,
     QStatusBar,
     QToolBar,


### PR DESCRIPTION
## Summary
- import `QShortcut` from `PyQt6.QtGui` instead of `PyQt6.QtWidgets`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d370edbb188322bb693f155a196c01