### PR TITLE
Guard settings loading against non-mapping config data

### DIFF
--- a/app/services/settings_service.py
+++ b/app/services/settings_service.py
@@ -44,7 +44,11 @@ class SettingsService(QObject):
         """Reload settings from disk."""
 
         data = self._config.load()
-        ui_settings = data.get("ui") if isinstance(data, dict) else {}
+        if not isinstance(data, dict):
+            data = {}
+        ui_settings = data.get("ui", {})
+        if not isinstance(ui_settings, dict):
+            ui_settings = {}
         theme = str(ui_settings.get("theme", DEFAULT_THEME)).lower()
         if theme not in {"light", "dark"}:
             theme = DEFAULT_THEME
@@ -63,7 +67,9 @@ class SettingsService(QObject):
         data = self._config.load()
         if not isinstance(data, dict):
             data = {}
-        ui_data = data.get("ui") if isinstance(data.get("ui"), dict) else {}
+        ui_data = data.get("ui")
+        if not isinstance(ui_data, dict):
+            ui_data = {}
         ui_data.update(
             {
                 "theme": self._settings.theme,


### PR DESCRIPTION
## Summary
- ensure the settings service treats non-dictionary config payloads as empty when reloading
- guard saving logic against non-mapping `ui` sections before updating persisted settings

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3789993788322a019cec5c1b0a2a5