### PR TITLE
Support additional text-based file types

### DIFF
--- a/app/ingest/parsers/__init__.py
+++ b/app/ingest/parsers/__init__.py
@@ -75,6 +75,12 @@ _PARSERS: dict[str, Parser] = {
     ".md": parse_markdown,
     ".markdown": parse_markdown,
     ".mkd": parse_markdown,
+    ".html": parse_text,
+    ".htm": parse_text,
+    ".py": parse_text,
+    ".pyw": parse_text,
+    ".m": parse_text,
+    ".cpp": parse_text,
 }
 
 

--- a/tests/test_parser_file_types.py
+++ b/tests/test_parser_file_types.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.ingest.parsers import parse_file
+
+
+def test_parse_file_supports_code_and_markup(tmp_path: Path) -> None:
+    samples = {
+        ".html": "<html><body>Sample HTML</body></html>",
+        ".py": "print('sample python file')\n",
+        ".m": "function y = square(x)\n    y = x.^2;\nend\n",
+        ".cpp": "#include <iostream>\nint main() { return 0; }\n",
+    }
+
+    for suffix, content in samples.items():
+        path = tmp_path / f"document{suffix}"
+        path.write_text(content, encoding="utf-8")
+
+        parsed = parse_file(path)
+
+        assert content.strip().splitlines()[0] in parsed.text
+        assert parsed.metadata["encoding"].lower() == "utf-8"


### PR DESCRIPTION
## Summary
- allow the text parser to handle HTML, Python, MATLAB, and C++ sources by registering their suffixes
- cover the newly supported types with a parser regression test

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3f50d31348322906a562980ba53d9