### PR TITLE
Add project database snapshots after ingestion

### DIFF
--- a/tests/test_project_service.py
+++ b/tests/test_project_service.py
@@ -32,6 +32,8 @@ def test_corpus_root_management(tmp_path: Path) -> None:
         with pytest.raises(RuntimeError):
             service.get_project_storage(project.id)
 
+        assert service.export_project_database_snapshot(project.id) is None
+
         first = tmp_path / "docs"
         first.mkdir()
         service.add_corpus_root(project.id, first)
@@ -42,6 +44,8 @@ def test_corpus_root_management(tmp_path: Path) -> None:
         assert storage_path.parent.name == "projects"
         assert storage_path.parent.parent.name == ".dataminer"
         assert storage_path.parent.parent.parent == first.resolve()
+        snapshot_path = storage_path / "dataminer.db"
+        assert snapshot_path.exists()
 
         # Adding the same folder again should not create duplicates.
         service.add_corpus_root(project.id, first)


### PR DESCRIPTION
## Summary
- add an export_project_database_snapshot helper to ProjectService that writes a SQLite copy into the project's storage folder and invoke it when corpus roots are added
- refresh the per-project snapshot once an ingest job completes so the GUI tracks the database location
- extend the project service tests to assert the snapshot is created and update UI logging utilities

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4105b19b883228d36ddb5e0377559