### PR TITLE
Implement chunked corpus indexing and retrieval context

### DIFF
--- a/app/ingest/service.py
+++ b/app/ingest/service.py
@@ -538,13 +538,22 @@ class IngestService:
         exclude_patterns = list(exclude)
 
         def _matches(pattern: str) -> bool:
-            if fnmatch(relative, pattern):
-                return True
             normalized_relative = relative.replace("\\", "/")
             normalized_pattern = pattern.replace("\\", "/")
-            if fnmatch(normalized_relative, normalized_pattern):
-                return True
-            return fnmatch(path.name, pattern)
+            candidates = [
+                relative,
+                relative.lower(),
+                normalized_relative,
+                normalized_relative.lower(),
+                path.name,
+                path.name.lower(),
+            ]
+            patterns = [pattern, pattern.lower(), normalized_pattern, normalized_pattern.lower()]
+            for candidate in candidates:
+                for current in patterns:
+                    if fnmatch(candidate, current):
+                        return True
+            return False
 
         if include_patterns and not any(_matches(pattern) for pattern in include_patterns):
             return False

--- a/app/retrieval/search.py
+++ b/app/retrieval/search.py
@@ -48,24 +48,88 @@ class SearchService:
             recursive=recursive,
         )
         documents_by_path = self._build_path_index(candidate_documents)
+        seen_documents: set[int] = set()
         results: list[dict[str, Any]] = []
-        for record in self.ingest.search(query, limit=limit * 3):
-            path = record.get("path")
+        for record in self.ingest.search(query, limit=limit * 6):
+            doc_payload = record.get("document") or {}
+            path = record.get("path") or doc_payload.get("path")
             if not path:
                 continue
-            document = documents_by_path.get(path)
+            document = documents_by_path.get(self._normalize_path(path))
             if document is None:
                 continue
+            doc_id = int(document.get("id"))
+            if doc_id in seen_documents:
+                continue
+            seen_documents.add(doc_id)
+            chunk: dict[str, Any] = record.get("chunk") or {}
+            chunk_text = chunk.get("text") if isinstance(chunk, dict) else None
+            highlight = record.get("highlight") or chunk_text or doc_payload.get("preview")
             results.append(
                 {
                     "document": document,
-                    "highlight": record.get("highlight") or record.get("preview"),
-                    "ingest_document": record,
+                    "highlight": highlight,
+                    "context": chunk_text or "",
+                    "chunk": chunk,
+                    "ingest_document": doc_payload,
+                    "score": record.get("score"),
                 }
             )
             if len(results) >= limit:
                 break
         return results
+
+    def retrieve_context_snippets(
+        self,
+        query: str,
+        *,
+        project_id: int,
+        limit: int = 5,
+        tags: Iterable[int] | None = None,
+        folder: str | Path | None = None,
+        recursive: bool = True,
+        include_identifiers: Iterable[str] | None = None,
+        exclude_identifiers: Iterable[str] | None = None,
+    ) -> list[str]:
+        scope_tags = list(tags) if tags is not None else None
+        scope_folder = self._normalize_folder(folder) if folder is not None else None
+        candidate_documents = self.documents.list_for_scope(
+            project_id,
+            tags=scope_tags,
+            folder=scope_folder,
+            recursive=recursive,
+        )
+        documents_by_path = self._build_path_index(candidate_documents)
+        include_set = {str(item) for item in (include_identifiers or []) if str(item)}
+        exclude_set = {str(item) for item in (exclude_identifiers or []) if str(item)}
+        snippets: list[str] = []
+        seen_chunks: set[int] = set()
+        for record in self.ingest.search(query, limit=limit * 6):
+            doc_payload = record.get("document") or {}
+            path = record.get("path") or doc_payload.get("path")
+            if not path:
+                continue
+            document = documents_by_path.get(self._normalize_path(path))
+            if document is None:
+                continue
+            identifiers = self._document_identifiers(document)
+            if include_set and include_set.isdisjoint(identifiers):
+                continue
+            if exclude_set and not exclude_set.isdisjoint(identifiers):
+                continue
+            chunk: dict[str, Any] = record.get("chunk") or {}
+            chunk_id = int(chunk.get("id", -1)) if isinstance(chunk, dict) else -1
+            if chunk_id in seen_chunks:
+                continue
+            text = chunk.get("text") if isinstance(chunk, dict) else None
+            if not text:
+                continue
+            title = document.get("title") or Path(path).stem or Path(path).name
+            snippets.append(f"{title}: {text.strip()}")
+            seen_chunks.add(chunk_id)
+            if len(snippets) >= limit:
+                break
+        return snippets
 
     def _resolve_scope(
         self,
@@ -103,6 +167,21 @@ class SearchService:
             normalized = self._normalize_path(source_path)
             index[normalized] = document
         return index
+
+    @staticmethod
+    def _document_identifiers(document: dict[str, Any]) -> set[str]:
+        identifiers: set[str] = set()
+        doc_id = document.get("id")
+        if doc_id is not None:
+            identifiers.add(str(doc_id))
+        source_path = document.get("source_path")
+        if source_path:
+            identifiers.add(str(source_path))
+            identifiers.add(SearchService._normalize_path(source_path))
+        title = document.get("title")
+        if isinstance(title, str) and title:
+            identifiers.add(title)
+        return identifiers
 
     @staticmethod
     def _normalize_path(path: str | Path) -> str:

--- a/app/storage/schema.sql
+++ b/app/storage/schema.sql
@@ -168,12 +168,32 @@ CREATE TABLE IF NOT EXISTS ingest_documents (
 
 CREATE INDEX IF NOT EXISTS idx_ingest_documents_path ON ingest_documents(path);
 
+CREATE TABLE IF NOT EXISTS ingest_document_chunks (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    document_id INTEGER NOT NULL,
+    chunk_index INTEGER NOT NULL,
+    text TEXT NOT NULL,
+    token_count INTEGER NOT NULL,
+    start_offset INTEGER NOT NULL,
+    end_offset INTEGER NOT NULL,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(document_id, chunk_index),
+    FOREIGN KEY (document_id) REFERENCES ingest_documents(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_ingest_chunks_document_id
+ON ingest_document_chunks(document_id);
+
 CREATE INDEX IF NOT EXISTS idx_documents_project_folder
 ON documents(project_id, folder_path);
 
-CREATE VIRTUAL TABLE IF NOT EXISTS ingest_document_index
+DROP TABLE IF EXISTS ingest_document_index;
+CREATE VIRTUAL TABLE ingest_document_index
 USING fts5(
     content,
+    path UNINDEXED,
     document_id UNINDEXED,
+    chunk_id UNINDEXED,
+    chunk_index UNINDEXED,
     tokenize='porter'
 );

--- a/tests/test_search_service.py
+++ b/tests/test_search_service.py
@@ -103,6 +103,7 @@ def test_search_service_scope_and_highlight(
     )
     assert [item["document"]["id"] for item in first_results] == [doc_alpha["id"]]
     assert "<mark>starlight</mark>" in first_results[0]["highlight"]
+    assert "starlight" in first_results[0]["context"]
 
     follow_up = service.search_documents(
         "starlight",
@@ -121,6 +122,13 @@ def test_search_service_scope_and_highlight(
         save_scope=True,
     )
     assert [item["document"]["id"] for item in updated_results] == [doc_beta["id"]]
+
+    contexts = service.retrieve_context_snippets(
+        "starlight",
+        project_id=project["id"],
+        include_identifiers=[str(doc_alpha["id"])],
+    )
+    assert any("starlight" in snippet for snippet in contexts)
 
 
 def test_document_hierarchy_service(


### PR DESCRIPTION
## Summary
- update the ingestion pipeline to chunk documents, persist chunk metadata in SQLite, and rebuild the FTS index at the chunk level
- extend the search service and UI to construct LMStudio context snippets from the corpus and refresh retrieval services when projects change
- broaden ingest glob handling and add tests covering chunk retrieval and contextual search

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d447c698748322aede58a0607bc9e0