### PR TITLE
Expand ingestion filters to handle additional file types

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,9 @@ Use the File → Corpus menu (or the toolbar shortcut) to load sources into the
 active project:
 
 1. Choose **Add Folder to Corpus…** to select an entire directory. All
-   supported files (`.pdf`, `.docx`, `.txt`, `.md`) inside the folder are queued
-   for background indexing.
+   supported files (`.pdf`, `.docx`, `.txt/.text`, `.md/.markdown/.mkd`,
+   `.html/.htm`, `.py/.pyw`, `.m`, `.cpp`) inside the folder are queued for
+   background indexing.
 2. Choose **Add Files to Corpus…** to index specific files without adding the
    surrounding folder.
 3. The status bar reports progress while files are parsed. When indexing

--- a/app/ingest/parsers/__init__.py
+++ b/app/ingest/parsers/__init__.py
@@ -84,6 +84,14 @@ _PARSERS: dict[str, Parser] = {
 }
 
 
+SUPPORTED_SUFFIXES: tuple[str, ...] = tuple(_PARSERS.keys())
+"""Ordered collection of supported file suffixes."""
+
+
+SUPPORTED_PATTERNS: tuple[str, ...] = tuple(f"*{suffix}" for suffix in SUPPORTED_SUFFIXES)
+"""Glob patterns corresponding to :data:`SUPPORTED_SUFFIXES`."""
+
+
 def register_parser(suffixes: Iterable[str], parser: Parser) -> None:
     """Register ``parser`` for the provided ``suffixes``."""
 
@@ -109,6 +117,8 @@ __all__ = [
     "PageContent",
     "ParsedDocument",
     "ParserError",
+    "SUPPORTED_PATTERNS",
+    "SUPPORTED_SUFFIXES",
     "parse_file",
     "register_parser",
 ]

--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -38,6 +38,7 @@ from PyQt6.QtWidgets import (
     QWidget,
 )
 
+from ..ingest.parsers import SUPPORTED_PATTERNS
 from ..ingest.service import IngestService, TaskStatus
 from ..retrieval import SearchService
 from ..services.conversation_manager import (
@@ -548,7 +549,11 @@ class MainWindow(QMainWindow):
     # ------------------------------------------------------------------
     # Corpus management
     def _ingest_include_patterns(self) -> list[str]:
-        return ["*.pdf", "*.docx", "*.txt", "*.text", "*.md", "*.markdown", "*.mkd"]
+        return list(SUPPORTED_PATTERNS)
+
+    def _ingest_file_filter_spec(self) -> str:
+        patterns = " ".join(self._ingest_include_patterns())
+        return f"Documents ({patterns});;All Files (*)"
 
     def _add_folder_to_corpus(self, _checked: bool = False) -> None:
         project = self.project_service.active_project()
@@ -589,9 +594,7 @@ class MainWindow(QMainWindow):
 
     def _add_files_to_corpus(self, _checked: bool = False) -> None:
         project = self.project_service.active_project()
-        filter_spec = (
-            "Documents (*.pdf *.docx *.txt *.text *.md *.markdown *.mkd);;All Files (*)"
-        )
+        filter_spec = self._ingest_file_filter_spec()
         files, _ = QFileDialog.getOpenFileNames(
             self,
             "Select Files to Index",


### PR DESCRIPTION
## Summary
- expose the parser's supported suffixes/patterns for reuse across the app
- update corpus ingestion filters and dialogs to allow html, python, matlab, and other text formats
- document the expanded support and add a UI test to keep filters aligned with the parser

## Testing
- PYTHONPATH=. pytest tests/test_parser_file_types.py tests/test_ui_main_window.py


------
https://chatgpt.com/codex/tasks/task_e_68d4524eb258832290e3a32a3409fef0