### PR TITLE
Handle structured LMStudio content

### DIFF
--- a/tests/test_lmstudio_integration.py
+++ b/tests/test_lmstudio_integration.py
@@ -91,6 +91,30 @@ def _default_chat_response(payload: dict[str, object]) -> dict[str, object]:
     }
 
 
+def test_lmstudio_client_parses_structured_content() -> None:
+    data = {
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        "Part one. ",
+                        {"type": "text", "text": "Part two."},
+                    ],
+                    "metadata": {
+                        "citations": [{"source": "doc", "snippet": "text"}],
+                    },
+                }
+            }
+        ]
+    }
+
+    message = LMStudioClient._parse_chat_response(data)
+
+    assert message.content == "Part one. Part two."
+    assert message.citations == [{"source": "doc", "snippet": "text"}]
+
+
 def _make_handler(state: dict[str, object]) -> type[BaseHTTPRequestHandler]:
     class Handler(BaseHTTPRequestHandler):
         def do_GET(self) -> None:  # noqa: N802 - signature defined by BaseHTTPRequestHandler


### PR DESCRIPTION
## Summary
- normalize LMStudio chat content so array-based responses parse without crashing
- cover structured message parsing with a regression test

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d53c968b9c83229fca5e7b89496f80