### PR TITLE
Ensure LMStudio requests include retrieval query

### DIFF
--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -1261,7 +1261,7 @@ class MainWindow(QMainWindow):
         progress_message = "Refreshing evidence..." if triggered_by_scope else "Submitting question..."
         self.progress_service.start("chat-send", progress_message)
         asked_at = datetime.now()
-        extra_options = self._build_extra_request_options()
+        extra_options = self._build_extra_request_options(question)
         try:
             turn = self._conversation_manager.ask(
                 question,
@@ -1293,13 +1293,20 @@ class MainWindow(QMainWindow):
         self.question_input.set_busy(False)
         self._update_question_prerequisites(self._conversation_manager.connection_state)
 
-    def _build_extra_request_options(self) -> dict[str, Any]:
+    def _build_extra_request_options(self, question: str | None = None) -> dict[str, Any]:
         options: dict[str, Any] = {}
         scope = self._current_retrieval_scope
         include = list(scope.get("include", [])) if scope else []
         exclude = list(scope.get("exclude", [])) if scope else []
-        if include or exclude:
-            options["retrieval"] = {"include": include, "exclude": exclude}
+        retrieval: dict[str, Any] = {}
+        if question and question.strip():
+            retrieval["query"] = question.strip()
+        if include:
+            retrieval["include"] = include
+        if exclude:
+            retrieval["exclude"] = exclude
+        if retrieval:
+            options["retrieval"] = retrieval
         return options
 
     def _build_context_snippets(self, question: str) -> list[str]:

--- a/tests/test_lmstudio_integration.py
+++ b/tests/test_lmstudio_integration.py
@@ -241,6 +241,23 @@ def test_lmstudio_client_and_conversation_manager_success(lmstudio_server: tuple
     assert "Context:" in messages[-1]["content"]
 
 
+def test_conversation_manager_populates_retrieval_query(
+    lmstudio_server: tuple[dict[str, object], str]
+) -> None:
+    state, base_url = lmstudio_server
+    client = LMStudioClient(base_url=base_url, retry_backoff=0.01)
+    manager = ConversationManager(client, context_window=0)
+
+    extra = {"retrieval": {"include": ["doc-1"]}}
+    manager.ask("Gather context please", extra_options=extra)
+
+    assert state["requests"] and isinstance(state["requests"], list)
+    payload = state["requests"][-1]
+    assert payload.get("retrieval", {}).get("query") == "Gather context please"
+    assert payload.get("retrieval", {}).get("include") == ["doc-1"]
+    assert "query" not in extra["retrieval"]
+
+
 def test_lmstudio_client_disables_streaming_by_default(
     lmstudio_server: tuple[dict[str, object], str]
 ) -> None:


### PR DESCRIPTION
## Summary
- ensure the conversation manager injects the user question into LMStudio retrieval options without mutating caller data
- include the active question when building UI retrieval options for LMStudio requests
- add an integration test that verifies retrieval queries are forwarded to LMStudio

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d55b760ac08322b2fcef990a72127d