### PR TITLE
Remove LMStudio timeout handling

### DIFF
--- a/app/services/lmstudio_client.py
+++ b/app/services/lmstudio_client.py
@@ -64,19 +64,13 @@ class LMStudioClient:
         *,
         base_url: str = DEFAULT_BASE_URL,
         model: str = "lmstudio",
-        timeout: float = 30.0,
         max_retries: int = 2,
         retry_backoff: float = 0.5,
-        timeout_per_token: float = 0.1,
-        timeout_max: float | None = None,
     ) -> None:
         self._base_url = base_url.rstrip("/") or DEFAULT_BASE_URL
         self._model = model
-        self.timeout = max(timeout, 0.0)
         self.max_retries = max(max_retries, 0)
         self.retry_backoff = retry_backoff
-        self.timeout_per_token = max(timeout_per_token, 0.0)
-        self.timeout_max = timeout_max if (timeout_max is None or timeout_max > 0) else None
 
     @property
     def base_url(self) -> str:
@@ -144,9 +138,8 @@ class LMStudioClient:
         request_obj = request.Request(url, data=data, headers=headers, method=method)
         last_error: Exception | None = None
         for attempt in range(self.max_retries + 1):
-            timeout = self._compute_timeout(payload)
             try:
-                with request.urlopen(request_obj, timeout=timeout) as response:
+                with request.urlopen(request_obj) as response:
                     status = response.getcode()
                     body = response.read()
                 if status >= 400:
@@ -163,15 +156,11 @@ class LMStudioClient:
                     break
             except error.URLError as exc:
                 if isinstance(exc.reason, (TimeoutError, socket.timeout)):
-                    last_error = LMStudioConnectionError(
-                        self._format_timeout_message(timeout)
-                    )
+                    last_error = LMStudioConnectionError("LMStudio request timed out")
                 else:
                     last_error = LMStudioConnectionError(str(exc.reason))
             except TimeoutError:
-                last_error = LMStudioConnectionError(
-                    self._format_timeout_message(timeout)
-                )
+                last_error = LMStudioConnectionError("LMStudio request timed out")
             if attempt < self.max_retries:
                 time.sleep(self.retry_backoff * (2**attempt))
         if isinstance(last_error, LMStudioError):
@@ -223,26 +212,6 @@ class LMStudioClient:
             reasoning=reasoning,
             raw_response=data,
         )
-
-    def _compute_timeout(self, payload: dict[str, Any] | None) -> float:
-        """Return an adaptive timeout for the pending request."""
-
-        timeout = self.timeout
-        if payload:
-            raw_tokens = payload.get("max_tokens")
-            try:
-                max_tokens = int(raw_tokens)
-            except (TypeError, ValueError):
-                max_tokens = 0
-            if max_tokens > 0 and self.timeout_per_token > 0:
-                timeout += max_tokens * self.timeout_per_token
-        if self.timeout_max is not None:
-            timeout = min(timeout, self.timeout_max)
-        return max(timeout, 1.0)
-
-    @staticmethod
-    def _format_timeout_message(timeout: float) -> str:
-        return f"LMStudio request timed out after {timeout:.1f}s"
 
     @staticmethod
     def _normalize_message_content(content: Any) -> str:


### PR DESCRIPTION
## Summary
- remove timeout configuration from the LMStudio client and stop sending deadlines to urlopen
- keep timeout-related connection errors informative without referencing a computed timeout value
- update LMStudio integration tests to confirm no timeout argument is used and timeout errors are still surfaced

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5678691f48322ae9a2e019c3e4be4