### PR TITLE
Add Windows batch launcher for DataMiner app

### DIFF
--- a/launch_app.bat
+++ b/launch_app.bat
@@ -1,0 +1,30 @@
+@echo off
+setlocal
+set "SCRIPT_DIR=%~dp0"
+
+if exist "%SCRIPT_DIR%\.venv\Scripts\python.exe" (
+    set "PYTHON=%SCRIPT_DIR%\.venv\Scripts\python.exe"
+) else (
+    call :find_python
+    if not defined PYTHON (
+        echo Could not locate Python. Ensure Python 3.11+ is installed or create a .venv folder.
+        exit /b 1
+    )
+)
+
+pushd "%SCRIPT_DIR%"
+"%PYTHON%" -m app %*
+set "APP_EXIT_CODE=%ERRORLEVEL%"
+popd
+exit /b %APP_EXIT_CODE%
+
+:find_python
+for %%P in (python.exe py.exe) do (
+    where %%P >nul 2>nul
+    if not errorlevel 1 (
+        set "PYTHON=%%P"
+        goto :eof
+    )
+)
+goto :eof
+


### PR DESCRIPTION
## Summary
- add a Windows `launch_app.bat` helper for starting the PyQt application
- prefer a local `.venv` interpreter when available and fall back to a system-wide Python installation

## Testing
- not run (Windows-only launcher script)


------
https://chatgpt.com/codex/tasks/task_e_68d6bba0b6b08322b88ad058d23881a5