### PR TITLE
Improve citation handling and add evidence re-ask action

### DIFF
--- a/tests/test_dynamic_planning.py
+++ b/tests/test_dynamic_planning.py
@@ -99,5 +99,6 @@ def test_dynamic_plan_notes_missing_citations() -> None:
 
     assert len(turn.step_results) == 2
     assert turn.reasoning_artifacts is not None
-    assert any("No citations" in text for text in turn.reasoning_artifacts.assumptions)
-    assert all(result.citation_indexes == [] for result in turn.step_results)
+    assert any("No direct evidence" in text for text in turn.reasoning_artifacts.assumptions)
+    assert all(result.citation_indexes for result in turn.step_results)
+    assert all(turn.citations)

--- a/tests/test_ui_main_window.py
+++ b/tests/test_ui_main_window.py
@@ -331,6 +331,13 @@ def test_evidence_scope_requery_and_preview(qt_app, tmp_path, monkeypatch, proje
     assert documents[0]["text"]
     assert documents[0]["id"]
 
+    reask_button = window._evidence_panel._reask_button
+    assert reask_button.isEnabled()
+    previous_calls = client.calls
+    reask_button.click()
+    qt_app.processEvents()
+    assert client.calls >= previous_calls + 1
+
     window.close()
 
 


### PR DESCRIPTION
## Summary
- add fallback citation generation from retrieved contexts so every step has supporting sources
- enhance the evidence panel with highlighted snippets, conflict summaries, and a re-ask control tied to the active question
- wire the main window to keep the evidence re-ask button in sync with conversation state and expand UI tests accordingly

## Testing
- pytest tests/test_dynamic_planning.py tests/test_ui_main_window.py

------
https://chatgpt.com/codex/tasks/task_e_68d6e29678108322a069bd34b3eda349