### PR TITLE
Normalize dynamic plan answers

### DIFF
--- a/tests/test_conversation_manager.py
+++ b/tests/test_conversation_manager.py
@@ -50,3 +50,30 @@ def test_compose_final_answer_deduplicates_and_merges_citations():
         "Quick tip Another tip [5][6]"
     )
     assert final_answer == expected
+
+
+def test_compose_final_answer_strips_step_prefixes():
+    step_results = [
+        StepResult(
+            index=1,
+            description="First",
+            answer="Step 1: Value found. [1]",
+            citation_indexes=[1],
+        ),
+        StepResult(
+            index=2,
+            description="Second",
+            answer="step 2 - Value found. [2]",
+            citation_indexes=[2],
+        ),
+        StepResult(
+            index=3,
+            description="Third",
+            answer="1) Value found. [3]",
+            citation_indexes=[3],
+        ),
+    ]
+
+    final_answer = ConversationManager._compose_final_answer(step_results)
+
+    assert final_answer == "Value found. [1][2][3]"

--- a/tests/test_dynamic_planning.py
+++ b/tests/test_dynamic_planning.py
@@ -68,8 +68,7 @@ def test_conversation_manager_executes_dynamic_plan() -> None:
     assert len(client.requests) == 2
     assert len(turn.step_results) == 2
     assert all(item.status == "done" for item in turn.plan)
-    assert "Step 1 finding" in turn.answer
-    assert "[1]" in turn.answer
+    assert turn.answer == "finding [1][2]"
     assert len(turn.citations) == 2
     assert turn.citations[0].get("steps") == [1]
     assert turn.step_results[0].citation_indexes == [1]


### PR DESCRIPTION
## Summary
- strip step numbering artifacts from dynamic planning step answers before composing the final reply
- deduplicate repeated findings with consolidated citation markers
- cover the new normalization path with tests for answer composition and dynamic planning

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6fc899054832298ff38803f39b7ab