### PR TITLE
Implement semantic section chunking and scoring

### DIFF
--- a/app/ingest/parsers/__init__.py
+++ b/app/ingest/parsers/__init__.py
@@ -27,6 +27,10 @@ class DocumentSection:
     content: str
     level: int | None = None
     page_number: int | None = None
+    start_offset: int | None = None
+    end_offset: int | None = None
+    line_start: int | None = None
+    line_end: int | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)

--- a/app/ingest/parsers/markdown_parser.py
+++ b/app/ingest/parsers/markdown_parser.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from . import DocumentSection, PageContent, ParsedDocument
 
-_HEADING_RE = re.compile(r"^(?P<level>#{1,6})\s*(?P<title>.+)$")
+_HEADING_RE = re.compile(r"^(?P<level>#{1,6})\s*(?P<title>.+?)\s*$")
 
 
 def parse_markdown(path: Path) -> ParsedDocument:
@@ -17,23 +17,58 @@ def parse_markdown(path: Path) -> ParsedDocument:
     sections: list[DocumentSection] = []
     current_section: DocumentSection | None = None
     body_lines: list[str] = []
+    heading_count = 0
+    char_offset = 0
+    line_number = 0
 
-    for line in text.splitlines():
-        match = _HEADING_RE.match(line.strip())
+    for raw_line in text.splitlines():
+        line_number += 1
+        line = raw_line.rstrip("\n")
+        stripped = line.strip()
+        match = _HEADING_RE.match(stripped)
         if match:
             level = len(match.group("level"))
             title = match.group("title").strip()
-            current_section = DocumentSection(title=title, content="", level=level)
+            heading_count += 1
+            current_section = DocumentSection(
+                title=title,
+                content="",
+                level=level,
+                page_number=1,
+                start_offset=char_offset,
+                end_offset=char_offset + len(line),
+                line_start=line_number,
+                line_end=line_number,
+            )
             sections.append(current_section)
+            body_lines.append(line)
+            char_offset += len(line) + 1
             continue
+
+        body_lines.append(line)
         if current_section is None:
-            current_section = DocumentSection(title=None, content="")
+            current_section = DocumentSection(
+                title=None,
+                content="",
+                level=None,
+                page_number=1,
+            )
             sections.append(current_section)
-        current_section.content += ("\n" if current_section.content else "") + line.rstrip()
-        body_lines.append(line.rstrip())
+
+        if stripped:
+            if current_section.content:
+                current_section.content += "\n"
+            current_section.content += line
+            if current_section.start_offset is None:
+                current_section.start_offset = char_offset
+            current_section.end_offset = char_offset + len(line)
+            if current_section.line_start is None:
+                current_section.line_start = line_number
+            current_section.line_end = line_number
+        char_offset += len(line) + 1
 
     sections = [section for section in sections if section.content or section.title]
     combined = "\n".join(body_lines)
     pages = [PageContent(number=1, text=combined)]
-    metadata = {"format": "markdown", "heading_count": len([s for s in sections if s.title])}
+    metadata = {"format": "markdown", "heading_count": heading_count}
     return ParsedDocument(text=combined, metadata=metadata, sections=sections, pages=pages)

--- a/app/ingest/parsers/pdf_parser.py
+++ b/app/ingest/parsers/pdf_parser.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import datetime as _dt
 from pathlib import Path
+from statistics import median
 from typing import Any
 
 from . import DocumentSection, PageContent, ParsedDocument, ParserError
@@ -43,25 +44,119 @@ def parse_pdf(path: Path) -> ParsedDocument:
         raise ParserError(str(exc)) from exc
 
     try:
-        texts: list[str] = []
+        document_lines: list[str] = []
         sections: list[DocumentSection] = []
         pages: list[PageContent] = []
         needs_ocr = True
+        heading_count = 0
+        current_section: DocumentSection | None = None
+        char_offset = 0
+        line_number = 0
 
         for index, page in enumerate(document, start=1):
-            text = page.get_text("text")
-            if text.strip():
-                needs_ocr = False
-            texts.append(text.strip())
-            sections.append(
-                DocumentSection(
-                    title=f"Page {index}",
-                    content=text.strip(),
-                    level=1,
-                    page_number=index,
-                )
-            )
-            pages.append(PageContent(number=index, text=text))
+            page_dict = page.get_text("dict")
+            line_candidates: list[dict[str, Any]] = []
+            span_sizes: list[float] = []
+
+            for block in page_dict.get("blocks", []):
+                for line in block.get("lines", []):
+                    spans = line.get("spans") or []
+                    if not spans:
+                        continue
+                    raw_text = "".join(span.get("text", "") for span in spans)
+                    text_line = raw_text.rstrip()
+                    is_blank = not text_line.strip()
+                    size = 0.0
+                    bold = False
+                    if not is_blank:
+                        numeric_sizes = [
+                            float(span.get("size", 0.0))
+                            for span in spans
+                            if str(span.get("text", "")).strip()
+                        ]
+                        if numeric_sizes:
+                            size = max(numeric_sizes)
+                            span_sizes.extend(numeric_sizes)
+                        bold = any(int(span.get("flags", 0)) & 2 for span in spans)
+                    line_candidates.append(
+                        {
+                            "text": text_line,
+                            "blank": is_blank,
+                            "size": size,
+                            "bold": bold,
+                            "page": index,
+                        }
+                    )
+
+            body_size = median(span_sizes) if span_sizes else 0.0
+            page_lines: list[str] = []
+
+            for entry in line_candidates:
+                text_line = entry["text"]
+                page_lines.append(text_line)
+                document_lines.append(text_line)
+                if entry["blank"]:
+                    char_offset += len(text_line) + 1 if text_line else 1
+                    line_number += 1
+                    continue
+
+                stripped = text_line.strip()
+                if stripped:
+                    needs_ocr = False
+
+                level: int | None = None
+                if body_size and stripped:
+                    relative = entry["size"] / body_size if body_size else 1.0
+                    word_count = len(stripped.split())
+                    if relative >= 1.8 and word_count <= 20:
+                        level = 1
+                    elif relative >= 1.45 and word_count <= 24:
+                        level = 2
+                    elif relative >= 1.25 and word_count <= 28:
+                        level = 3
+                    elif entry["bold"] and relative >= 1.1 and word_count <= 20:
+                        level = 3
+
+                if level is not None:
+                    heading_count += 1
+                    current_section = DocumentSection(
+                        title=stripped,
+                        content="",
+                        level=level,
+                        page_number=index,
+                        start_offset=char_offset,
+                        end_offset=char_offset + len(text_line),
+                        line_start=line_number + 1,
+                        line_end=line_number + 1,
+                    )
+                    sections.append(current_section)
+                    char_offset += len(text_line) + 1
+                    line_number += 1
+                    continue
+
+                if current_section is None:
+                    current_section = DocumentSection(
+                        title=None,
+                        content="",
+                        level=None,
+                        page_number=index,
+                        start_offset=char_offset,
+                        line_start=line_number + 1,
+                    )
+                    sections.append(current_section)
+
+                if current_section.content:
+                    current_section.content += "\n"
+                current_section.content += text_line
+                current_section.end_offset = char_offset + len(text_line)
+                current_section.line_end = line_number + 1
+                if current_section.line_start is None:
+                    current_section.line_start = line_number + 1
+
+                char_offset += len(text_line) + 1
+                line_number += 1
+
+            pages.append(PageContent(number=index, text="\n".join(page_lines)))
 
         metadata = {key: value for key, value in (document.metadata or {}).items() if value}
         if document.page_count is not None:
@@ -80,10 +175,11 @@ def parse_pdf(path: Path) -> ParsedDocument:
             else None
         )
 
-        combined_text = "\n\n".join(filter(None, texts))
+        sections = [section for section in sections if section.content or section.title]
+        combined_text = "\n".join(document_lines).strip()
         return ParsedDocument(
             text=combined_text,
-            metadata=metadata,
+            metadata={**metadata, "heading_count": heading_count},
             sections=sections,
             pages=pages,
             needs_ocr=needs_ocr,

--- a/app/ingest/parsers/text_parser.py
+++ b/app/ingest/parsers/text_parser.py
@@ -25,6 +25,18 @@ def parse_text(path: Path) -> ParsedDocument:
             text = raw.decode(encoding, errors="replace")
 
     metadata = {"encoding": encoding}
-    sections = [DocumentSection(title=None, content=text)]
+    line_count = text.count("\n") + 1 if text else 0
+    sections = [
+        DocumentSection(
+            title=None,
+            content=text,
+            level=None,
+            page_number=1,
+            start_offset=0,
+            end_offset=len(text),
+            line_start=1 if line_count else None,
+            line_end=line_count if line_count else None,
+        )
+    ]
     pages = [PageContent(number=1, text=text)]
     return ParsedDocument(text=text, metadata=metadata, sections=sections, pages=pages)

--- a/app/storage/schema.sql
+++ b/app/storage/schema.sql
@@ -176,6 +176,7 @@ CREATE TABLE IF NOT EXISTS ingest_document_chunks (
     token_count INTEGER NOT NULL,
     start_offset INTEGER NOT NULL,
     end_offset INTEGER NOT NULL,
+    metadata TEXT,
     created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
     UNIQUE(document_id, chunk_index),
     FOREIGN KEY (document_id) REFERENCES ingest_documents(id) ON DELETE CASCADE

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -198,6 +198,10 @@ def test_ingest_chunk_storage(
     assert record is not None
     chunk_results = ingest_repo.search_chunks("gamma", limit=5)
     assert chunk_results
+    first_chunk = chunk_results[0]["chunk"]
+    assert "metadata" in first_chunk
+    assert "hierarchy_weight" in first_chunk["metadata"]
+    assert "score_breakdown" in chunk_results[0]
     texts = [entry["chunk"]["text"] for entry in chunk_results if entry.get("chunk")]
     assert any("gamma" in text for text in texts)
     count = ingest_repo.db.connect().execute(


### PR DESCRIPTION
## Summary
- capture line and offset metadata when parsing markdown, DOCX, PDF, and text files for richer sections
- replace token-based ingest chunking with semantic section windows, persist chunk metadata, and blend keyword, semantic, and hierarchy scores
- extend the ingest schema and tests to validate metadata-aware chunks

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dae1e887b083228054dbfe4f7d4aff