### PR TITLE
Ensure single-shot answers use retrieval context for citations

### DIFF
--- a/app/services/conversation_manager.py
+++ b/app/services/conversation_manager.py
@@ -1471,6 +1471,7 @@ class ConversationManager:
             response_mode,
             extra_options,
         )
+        fallback_documents = self._extract_retrieval_documents(request_options)
         try:
             response = self.client.chat(
                 messages,
@@ -1482,6 +1483,17 @@ class ConversationManager:
             raise
 
         self._update_connection(True, None)
+        if not response.citations and fallback_documents:
+            inferred = self._fallback_citations_from_contexts(
+                [StepContextBatch(snippets=[], documents=list(fallback_documents))]
+            )
+            if inferred:
+                response = ChatMessage(
+                    content=response.content,
+                    citations=inferred,
+                    reasoning=response.reasoning,
+                    raw_response=response.raw_response,
+                )
         turn = self._register_turn(question, response, response_mode, preset)
         return turn
 
@@ -2319,6 +2331,22 @@ class ConversationManager:
             if normalized_question and (query is None or not str(query).strip()):
                 retrieval["query"] = normalized_question
         return options
+
+    @staticmethod
+    def _extract_retrieval_documents(options: dict[str, Any]) -> list[dict[str, Any]]:
+        retrieval = options.get("retrieval") if isinstance(options, dict) else None
+        if not isinstance(retrieval, dict):
+            return []
+        documents = retrieval.get("documents")
+        if isinstance(documents, dict):
+            return [dict(documents)]
+        if isinstance(documents, Iterable) and not isinstance(documents, (str, bytes)):
+            normalized: list[dict[str, Any]] = []
+            for document in documents:
+                if isinstance(document, dict):
+                    normalized.append(dict(document))
+            return normalized
+        return []
 
     def _merge_step_options(
         self,

--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -1534,11 +1534,16 @@ class MainWindow(QMainWindow):
         progress_message = "Refreshing evidence..." if triggered_by_scope else "Submitting question..."
         self.progress_service.start("chat-send", progress_message)
         asked_at = datetime.now()
+        context_snippets, retrieval_documents = self._prepare_retrieval_context(question)
         step_context_provider = self._build_step_context_provider(question)
-        extra_options = self._build_extra_request_options(question)
+        extra_options = self._build_extra_request_options(
+            question,
+            retrieval_documents=retrieval_documents or None,
+        )
         try:
             turn = self._conversation_manager.ask(
                 question,
+                context_snippets=context_snippets or None,
                 reasoning_verbosity=self.conversation_settings.reasoning_verbosity,
                 response_mode=self.conversation_settings.response_mode,
                 preset=self.conversation_settings.answer_length,
@@ -1655,6 +1660,7 @@ class MainWindow(QMainWindow):
             project_id=project_id,
             include_identifiers=include,
             exclude_identifiers=exclude,
+            limit=9,
         )
         return self._context_payload_from_records(records, project_id)
 

--- a/tests/test_dynamic_planning.py
+++ b/tests/test_dynamic_planning.py
@@ -124,6 +124,51 @@ def test_dynamic_plan_notes_missing_citations() -> None:
     assert all(turn.citations)
 
 
+def test_single_shot_uses_retrieval_documents_for_citations() -> None:
+    class NoCitationSingleShotClient(StubLMStudioClient):
+        def chat(self, messages, *, preset, extra_options=None) -> ChatMessage:  # type: ignore[override]
+            self.requests.append({"messages": list(messages), "options": extra_options})
+            return ChatMessage(
+                content="Evidence summary",
+                citations=[],
+                reasoning=None,
+                raw_response={"choices": []},
+            )
+
+    client = NoCitationSingleShotClient()
+    manager = ConversationManager(client)
+
+    documents = [
+        {
+            "id": "doc-1",
+            "source": "Doc 1",
+            "snippet": "<mark>Key finding</mark>",
+            "text": "Key finding",
+        }
+    ]
+
+    turn = manager.ask(
+        "Summarize the findings.",
+        context_snippets=["Doc 1\nKey finding"],
+        extra_options={"retrieval": {"documents": documents}},
+    )
+
+    assert client.requests
+    recorded = client.requests[0]
+    options = recorded.get("options")
+    assert isinstance(options, dict)
+    retrieval = options.get("retrieval") if isinstance(options, dict) else None
+    assert isinstance(retrieval, dict)
+    assert retrieval.get("documents")
+
+    assert turn.citations
+    first_citation = turn.citations[0]
+    assert isinstance(first_citation, dict)
+    assert first_citation.get("source") == "Doc 1"
+    assert "<mark>" in first_citation.get("snippet", "")
+    assert turn.answer.rstrip().endswith("[1]")
+
+
 def test_plan_critic_rejects_meta_steps() -> None:
     client = StubLMStudioClient()
     manager = ConversationManager(client)


### PR DESCRIPTION
## Summary
- pass prepared retrieval snippets and documents from the UI into chat requests so single-shot conversations always include scoped context
- derive fallback citations from retrieval documents whenever the model omits them, ensuring answers still reference evidence
- cover the new behaviour with a regression test that verifies single-shot requests record documents and expose inferred citations

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68daecbece68832292f2c61ee23d011e