### PR TITLE
Ignore reasoning chunks in LMStudio responses

### DIFF
--- a/app/services/lmstudio_client.py
+++ b/app/services/lmstudio_client.py
@@ -222,10 +222,24 @@ class LMStudioClient:
             for item in content:
                 if isinstance(item, str):
                     parts.append(item)
-                elif isinstance(item, dict):
-                    text = item.get("text")
-                    if isinstance(text, str):
-                        parts.append(text)
+                    continue
+                if not isinstance(item, dict):
+                    continue
+
+                type_value = item.get("type")
+                if isinstance(type_value, str) and "reasoning" in type_value.lower():
+                    continue
+                if item.get("is_reasoning") is True:
+                    continue
+
+                text = item.get("text")
+                if isinstance(text, str):
+                    parts.append(text)
+                    continue
+
+                content_text = item.get("content")
+                if isinstance(content_text, str):
+                    parts.append(content_text)
             if parts:
                 return "".join(parts)
         raise LMStudioResponseError("LMStudio message missing content")

--- a/tests/test_lmstudio_integration.py
+++ b/tests/test_lmstudio_integration.py
@@ -117,6 +117,30 @@ def test_lmstudio_client_parses_structured_content() -> None:
     assert message.citations == [{"source": "doc", "snippet": "text"}]
 
 
+def test_lmstudio_client_ignores_reasoning_chunks() -> None:
+    data = {
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "reasoning", "text": "Thinking..."},
+                        {"type": "output_text", "text": "Final answer."},
+                    ],
+                    "metadata": {
+                        "reasoning": {"steps": ["Thinking..."]},
+                    },
+                }
+            }
+        ]
+    }
+
+    message = LMStudioClient._parse_chat_response(data)
+
+    assert message.content == "Final answer."
+    assert message.reasoning == {"steps": ["Thinking..."]}
+
+
 def test_lmstudio_client_handles_nested_citation_container() -> None:
     data = {
         "choices": [


### PR DESCRIPTION
## Summary
- update the LMStudio client to skip reasoning chunks when normalizing message content
- ensure other structured content shapes remain supported while preserving reasoning metadata
- add a regression test covering reasoning and output chunks in chat responses

## Testing
- PYTHONPATH=. pytest tests/test_lmstudio_integration.py::test_lmstudio_client_ignores_reasoning_chunks

------
https://chatgpt.com/codex/tasks/task_e_68daf18930ec83228f8562eca5780470