### PR TITLE
Handle case-insensitive ingest filter patterns

### DIFF
--- a/app/ingest/service.py
+++ b/app/ingest/service.py
@@ -616,20 +616,19 @@ class IngestService:
         def _matches(pattern: str) -> bool:
             normalized_relative = relative.replace("\\", "/")
             normalized_pattern = pattern.replace("\\", "/")
-            candidates = [
-                relative,
-                relative.lower(),
-                normalized_relative,
-                normalized_relative.lower(),
-                path.name,
-                path.name.lower(),
-            ]
-            patterns = [pattern, pattern.lower(), normalized_pattern, normalized_pattern.lower()]
-            for candidate in candidates:
-                for current in patterns:
-                    if fnmatch(candidate, current):
-                        return True
-            return False
+            if fnmatch(relative, pattern):
+                return True
+            if fnmatch(normalized_relative, normalized_pattern):
+                return True
+            if fnmatch(path.name, pattern):
+                return True
+
+            folded_relative = normalized_relative.casefold()
+            folded_name = path.name.casefold()
+            folded_pattern = normalized_pattern.casefold()
+            if fnmatch(folded_relative, folded_pattern):
+                return True
+            return fnmatch(folded_name, folded_pattern)
 
         if include_patterns and not any(_matches(pattern) for pattern in include_patterns):
             return False


### PR DESCRIPTION
## Summary
- normalize ingest filter comparisons to handle mixed-case file names
- add case-folded fallbacks so include/exclude patterns catch uppercase paths

## Testing
- python - <<'PY'
from app.ingest.service import IngestService
from app.storage.database import DatabaseManager
from pathlib import Path
import tempfile, time

root = Path(tempfile.mkdtemp())
(root/'FILE.PDF').write_text('pdf placeholder')
db = DatabaseManager(root/'db.sqlite3')
db.initialize()
ingest = IngestService(db)
include = ['*.pdf', '*.txt']
job_id = ingest.queue_folder_crawl(None, root, include=include)
for _ in range(50):
    job = ingest._jobs.get(job_id)
    if job and job.status == 'completed':
        break
    time.sleep(0.1)
job = ingest._jobs.get(job_id)
print(job.summary)
PY

------
https://chatgpt.com/codex/tasks/task_e_68db491b40248322a8b3741c141e64a9