### PR TITLE
Sanitize parser metadata before storing ingest documents

### DIFF
--- a/app/storage/database.py
+++ b/app/storage/database.py
@@ -12,6 +12,8 @@ import threading
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Iterable
 
+from app.storage.json_utils import make_json_safe
+
 if TYPE_CHECKING:
     from app.ingest.parsers import ParsedDocument
 
@@ -545,6 +547,9 @@ class IngestDocumentRepository(BaseRepository):
         normalized_path = str(Path(path).resolve())
         metadata = dict(base_metadata or {})
         metadata.update(parsed.metadata)
+        metadata = make_json_safe(metadata)
+        if not isinstance(metadata, dict):
+            metadata = {"metadata": metadata}
         metadata_json = json.dumps(metadata, ensure_ascii=False)
         sections_json = json.dumps(
             [section.to_dict() for section in parsed.sections], ensure_ascii=False


### PR DESCRIPTION
## Summary
- sanitize parser metadata before persisting ingest documents so background jobs no longer fail on non-JSON values
- ensure metadata serialization always produces a mapping even if sanitization returns a non-dict

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68db5792d2fc8322b6b7150221c1d3f3