### PR TITLE
Add crash logging dialog and exception hooks

### DIFF
--- a/app/__main__.py
+++ b/app/__main__.py
@@ -6,7 +6,7 @@ import sys
 
 from PyQt6.QtWidgets import QApplication
 
-from .logging import setup_logging
+from .logging import install_exception_hook, setup_logging
 from .ingest.service import IngestService
 from .services.backup_service import BackupService
 from .services.document_hierarchy import DocumentHierarchyService
@@ -21,6 +21,7 @@ from .ui import MainWindow
 def main() -> None:
     """Start the PyQt6 application."""
     logger = setup_logging()
+    install_exception_hook(logger)
     logger.debug("Starting QApplication")
 
     app = QApplication(sys.argv)

--- a/app/logging.py
+++ b/app/logging.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import logging
+import sys
+import threading
+import traceback
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from typing import Optional
@@ -12,6 +15,9 @@ from .config import get_user_config_dir
 LOG_FILENAME = "dataminer.log"
 MAX_BYTES = 1_048_576  # 1 MiB
 BACKUP_COUNT = 3
+
+_EXCEPTION_HOOK_INSTALLED = False
+_HOOK_LOCK = threading.Lock()
 
 
 def setup_logging(
@@ -52,8 +58,125 @@ def setup_logging(
     console_handler.setFormatter(formatter)
     logger.addHandler(console_handler)
 
+    setattr(logger, "log_path", log_path)
     logger.debug("Logging initialised. Writing to %s", log_path)
     return logger
 
 
-__all__ = ["setup_logging"]
+def get_log_file_path(logger: logging.Logger) -> Optional[Path]:
+    """Return the path of the first file handler attached to ``logger``."""
+
+    log_path = getattr(logger, "log_path", None)
+    if isinstance(log_path, Path):
+        return log_path
+
+    for handler in logger.handlers:
+        filename = getattr(handler, "baseFilename", None)
+        if filename:
+            return Path(filename)
+    return None
+
+
+def install_exception_hook(logger: logging.Logger) -> None:
+    """Install handlers that log and surface unhandled exceptions."""
+
+    global _EXCEPTION_HOOK_INSTALLED
+    with _HOOK_LOCK:
+        if _EXCEPTION_HOOK_INSTALLED:
+            return
+        _EXCEPTION_HOOK_INSTALLED = True
+
+    log_path = get_log_file_path(logger)
+    default_hook = sys.excepthook
+
+    def handle_exception(exc_type, exc_value, exc_traceback):
+        if issubclass(exc_type, KeyboardInterrupt):
+            default_hook(exc_type, exc_value, exc_traceback)
+            return
+
+        logger.critical(
+            "Unhandled exception", exc_info=(exc_type, exc_value, exc_traceback)
+        )
+        formatted = "".join(
+            traceback.format_exception(exc_type, exc_value, exc_traceback)
+        )
+        _show_log_dialog(logger, formatted, log_path)
+        default_hook(exc_type, exc_value, exc_traceback)
+
+    sys.excepthook = handle_exception
+
+    thread_hook = getattr(threading, "excepthook", None)
+    if thread_hook is not None:
+
+        def handle_thread_exception(args):
+            if issubclass(args.exc_type, KeyboardInterrupt):
+                thread_hook(args)
+                return
+
+            logger.critical(
+                "Unhandled exception in thread %s",
+                args.thread.name,
+                exc_info=(args.exc_type, args.exc_value, args.exc_traceback),
+            )
+            formatted_thread = "".join(
+                traceback.format_exception(
+                    args.exc_type, args.exc_value, args.exc_traceback
+                )
+            )
+            _show_log_dialog(logger, formatted_thread, log_path)
+            thread_hook(args)
+
+        threading.excepthook = handle_thread_exception
+
+
+def _show_log_dialog(
+    logger: logging.Logger, traceback_text: str, log_path: Optional[Path]
+) -> None:
+    """Display a dialog containing the traceback and recent log output."""
+
+    try:
+        from PyQt6.QtCore import QTimer
+        from PyQt6.QtWidgets import QApplication
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.error("Unable to import PyQt6 components for crash dialog: %s", exc)
+        return
+
+    is_main_thread = threading.current_thread() is threading.main_thread()
+    app = QApplication.instance()
+    created_app = False
+    if app is None:
+        if not is_main_thread:
+            logger.error(
+                "Cannot display crash dialog on non-main thread without QApplication"
+            )
+            return
+        try:
+            app = QApplication(sys.argv or ["DataMiner"])
+            created_app = True
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.error("Failed to create QApplication for crash dialog: %s", exc)
+            return
+
+    def _exec_dialog() -> None:
+        try:
+            from .ui.log_viewer_dialog import LogViewerDialog
+
+            dialog = LogViewerDialog(
+                log_path=log_path,
+                traceback_text=traceback_text,
+                parent=app.activeWindow(),
+            )
+            dialog.exec()
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.error("Failed to display crash dialog: %s", exc)
+        finally:
+            if created_app:
+                app.quit()
+
+    if is_main_thread:
+        _exec_dialog()
+    else:
+        QTimer.singleShot(0, _exec_dialog)
+
+
+__all__ = ["setup_logging", "install_exception_hook", "get_log_file_path"]

--- a/app/ui/__init__.py
+++ b/app/ui/__init__.py
@@ -2,7 +2,14 @@
 
 from .answer_view import AnswerView
 from .evidence_panel import EvidencePanel
+from .log_viewer_dialog import LogViewerDialog
 from .main_window import MainWindow
 from .question_input_widget import QuestionInputWidget
 
-__all__ = ["AnswerView", "EvidencePanel", "MainWindow", "QuestionInputWidget"]
+__all__ = [
+    "AnswerView",
+    "EvidencePanel",
+    "LogViewerDialog",
+    "MainWindow",
+    "QuestionInputWidget",
+]

--- a/app/ui/log_viewer_dialog.py
+++ b/app/ui/log_viewer_dialog.py
@@ -1,0 +1,136 @@
+"""Dialog for presenting crash tracebacks and recent log output."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from PyQt6.QtCore import Qt, QUrl
+from PyQt6.QtGui import QFont, QGuiApplication, QTextOption
+from PyQt6.QtWidgets import (
+    QDialog,
+    QDialogButtonBox,
+    QGridLayout,
+    QLabel,
+    QPushButton,
+    QSizePolicy,
+    QTextEdit,
+    QWidget,
+)
+
+
+LOG_PREVIEW_LIMIT = 20_000
+
+
+class LogViewerDialog(QDialog):
+    """Display a formatted traceback alongside recent log file output."""
+
+    def __init__(
+        self,
+        *,
+        log_path: Optional[Path],
+        traceback_text: str,
+        parent: Optional[QWidget] = None,
+    ) -> None:
+        super().__init__(parent)
+        self._log_path = log_path
+        self._traceback_text = traceback_text.strip()
+        self.setWindowTitle("DataMiner Crash Report")
+        self.resize(960, 640)
+
+        layout = QGridLayout(self)
+        layout.setColumnStretch(0, 1)
+
+        header = QLabel(
+            "An unexpected error occurred. The traceback and recent log output "
+            "are shown below so that the issue can be diagnosed quickly."
+        )
+        header.setWordWrap(True)
+        header.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Maximum)
+        layout.addWidget(header, 0, 0)
+
+        traceback_label = QLabel("Traceback")
+        traceback_label.setAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter)
+        traceback_label.setStyleSheet("font-weight: bold;")
+        layout.addWidget(traceback_label, 1, 0)
+
+        traceback_view = QTextEdit(self)
+        traceback_view.setReadOnly(True)
+        traceback_view.setWordWrapMode(QTextOption.WrapMode.NoWrap)
+        monospaced = _monospace_font()
+        traceback_view.setFont(monospaced)
+        traceback_view.setPlainText(self._traceback_text or "Traceback unavailable.")
+        layout.addWidget(traceback_view, 2, 0)
+
+        log_label = QLabel("Recent log output" + (f" ({log_path})" if log_path else ""))
+        log_label.setAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter)
+        log_label.setStyleSheet("font-weight: bold;")
+        layout.addWidget(log_label, 3, 0)
+
+        log_view = QTextEdit(self)
+        log_view.setReadOnly(True)
+        log_view.setWordWrapMode(QTextOption.WrapMode.NoWrap)
+        log_view.setFont(monospaced)
+        log_view.setPlainText(self._load_log_preview())
+        layout.addWidget(log_view, 4, 0)
+
+        button_box = QDialogButtonBox(QDialogButtonBox.StandardButton.Close, parent=self)
+        button_box.rejected.connect(self.reject)
+        button_box.accepted.connect(self.accept)
+        layout.addWidget(button_box, 5, 0, alignment=Qt.AlignmentFlag.AlignRight)
+
+        if log_path:
+            open_button = QPushButton("Open Log File", self)
+            open_button.clicked.connect(self._open_log_location)
+            button_box.addButton(open_button, QDialogButtonBox.ButtonRole.ActionRole)
+
+        copy_button = QPushButton("Copy Traceback", self)
+        copy_button.clicked.connect(self._copy_traceback)
+        button_box.addButton(copy_button, QDialogButtonBox.ButtonRole.ActionRole)
+
+    def _load_log_preview(self) -> str:
+        if not self._log_path:
+            return "Log file location unknown."
+
+        try:
+            data = self._log_path.read_text(encoding="utf-8")
+        except OSError as exc:
+            return f"Unable to read log file: {exc}"
+
+        if not data.strip():
+            return "Log file is currently empty."
+
+        if len(data) > LOG_PREVIEW_LIMIT:
+            data = data[-LOG_PREVIEW_LIMIT:]
+            # Ensure we start from a newline boundary when truncating.
+            newline = data.find("\n")
+            if newline > 0:
+                data = data[newline + 1 :]
+            data = "… (log truncated)\n" + data
+        return data
+
+    def _open_log_location(self) -> None:
+        if not self._log_path:
+            return
+        if QDesktopServices is None:
+            return
+        QDesktopServices.openUrl(QUrl.fromLocalFile(str(self._log_path)))
+
+    def _copy_traceback(self) -> None:
+        clipboard = QGuiApplication.clipboard()
+        clipboard.setText(self._traceback_text)
+
+try:  # pragma: no cover - optional import depending on Qt bindings
+    from PyQt6.QtGui import QDesktopServices, QFontDatabase
+except ImportError:  # pragma: no cover
+    QDesktopServices = None
+    QFontDatabase = None
+
+
+def _monospace_font() -> QFont:
+    if QFontDatabase is None:
+        font = QFont("Monospace")
+        font.setStyleHint(QFont.StyleHint.TypeWriter)
+        return font
+    return QFontDatabase.systemFont(QFontDatabase.SystemFont.FixedFont)
+


### PR DESCRIPTION
## Summary
- install global exception hooks so unhandled errors are logged and surfaced to the user
- add a dedicated PyQt dialog that displays the traceback, recent log output, and quick actions when the app crashes
- expose the log viewer dialog in the UI package and initialise the hooks during application startup

## Testing
- pytest
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68db5ca81d6c832289978de5b4564c59