### PR TITLE
Support ingestion of code file extensions

### DIFF
--- a/app/ingest/parsers/__init__.py
+++ b/app/ingest/parsers/__init__.py
@@ -27,10 +27,6 @@ class DocumentSection:
     content: str
     level: int | None = None
     page_number: int | None = None
-    start_offset: int | None = None
-    end_offset: int | None = None
-    line_start: int | None = None
-    line_end: int | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -71,21 +67,30 @@ from .text_parser import parse_text
 Parser = Callable[[Path], ParsedDocument]
 
 
+_TEXT_SUFFIXES = (
+    ".txt",
+    ".text",
+    ".html",
+    ".htm",
+)
+
+_CODE_SUFFIXES = (
+    ".py",
+    ".pyw",
+    ".m",
+    ".cpp",
+)
+
 _PARSERS: dict[str, Parser] = {
     ".pdf": parse_pdf,
     ".docx": parse_docx,
-    ".txt": parse_text,
-    ".text": parse_text,
     ".md": parse_markdown,
     ".markdown": parse_markdown,
     ".mkd": parse_markdown,
-    ".html": parse_text,
-    ".htm": parse_text,
-    ".py": parse_text,
-    ".pyw": parse_text,
-    ".m": parse_text,
-    ".cpp": parse_text,
 }
+
+for suffix in (*_TEXT_SUFFIXES, *_CODE_SUFFIXES):
+    _PARSERS[suffix] = parse_text
 
 
 SUPPORTED_SUFFIXES: tuple[str, ...] = tuple(_PARSERS.keys())

--- a/app/ingest/parsers/docx_parser.py
+++ b/app/ingest/parsers/docx_parser.py
@@ -48,14 +48,10 @@ def parse_docx(path: Path) -> ParsedDocument:
     sections: list[DocumentSection] = []
     current_section: DocumentSection | None = None
     body_parts: list[str] = []
-    char_offset = 0
-    line_number = 0
 
     for paragraph in document.paragraphs:
-        text = paragraph.text.rstrip()
+        text = paragraph.text.strip()
         if not text:
-            char_offset += 1
-            line_number += 1
             continue
         body_parts.append(text)
         style_name = paragraph.style.name if paragraph.style is not None else ""
@@ -64,39 +60,15 @@ def parse_docx(path: Path) -> ParsedDocument:
                 level = int("".join(filter(str.isdigit, style_name)))
             except ValueError:
                 level = None
-            current_section = DocumentSection(
-                title=text,
-                content="",
-                level=level,
-                page_number=1,
-                start_offset=char_offset,
-                end_offset=char_offset + len(text),
-                line_start=line_number + 1,
-                line_end=line_number + 1,
-            )
+            current_section = DocumentSection(title=text, content="", level=level)
             sections.append(current_section)
-            char_offset += len(text) + 1
-            line_number += 1
             continue
         if current_section is None:
-            current_section = DocumentSection(
-                title=None,
-                content="",
-                level=None,
-                page_number=1,
-                start_offset=char_offset,
-                line_start=line_number + 1,
-            )
+            current_section = DocumentSection(title=None, content="")
             sections.append(current_section)
         if current_section.content:
             current_section.content += "\n"
         current_section.content += text
-        current_section.end_offset = char_offset + len(text)
-        current_section.line_end = line_number + 1
-        if current_section.line_start is None:
-            current_section.line_start = line_number + 1
-        char_offset += len(text) + 1
-        line_number += 1
 
     # Remove empty trailing sections to keep output compact.
     sections = [section for section in sections if section.content or section.title]

--- a/app/ingest/parsers/markdown_parser.py
+++ b/app/ingest/parsers/markdown_parser.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from . import DocumentSection, PageContent, ParsedDocument
 
-_HEADING_RE = re.compile(r"^(?P<level>#{1,6})\s*(?P<title>.+?)\s*$")
+_HEADING_RE = re.compile(r"^(?P<level>#{1,6})\s*(?P<title>.+)$")
 
 
 def parse_markdown(path: Path) -> ParsedDocument:
@@ -17,58 +17,23 @@ def parse_markdown(path: Path) -> ParsedDocument:
     sections: list[DocumentSection] = []
     current_section: DocumentSection | None = None
     body_lines: list[str] = []
-    heading_count = 0
-    char_offset = 0
-    line_number = 0
 
-    for raw_line in text.splitlines():
-        line_number += 1
-        line = raw_line.rstrip("\n")
-        stripped = line.strip()
-        match = _HEADING_RE.match(stripped)
+    for line in text.splitlines():
+        match = _HEADING_RE.match(line.strip())
         if match:
             level = len(match.group("level"))
             title = match.group("title").strip()
-            heading_count += 1
-            current_section = DocumentSection(
-                title=title,
-                content="",
-                level=level,
-                page_number=1,
-                start_offset=char_offset,
-                end_offset=char_offset + len(line),
-                line_start=line_number,
-                line_end=line_number,
-            )
+            current_section = DocumentSection(title=title, content="", level=level)
             sections.append(current_section)
-            body_lines.append(line)
-            char_offset += len(line) + 1
             continue
-
-        body_lines.append(line)
         if current_section is None:
-            current_section = DocumentSection(
-                title=None,
-                content="",
-                level=None,
-                page_number=1,
-            )
+            current_section = DocumentSection(title=None, content="")
             sections.append(current_section)
-
-        if stripped:
-            if current_section.content:
-                current_section.content += "\n"
-            current_section.content += line
-            if current_section.start_offset is None:
-                current_section.start_offset = char_offset
-            current_section.end_offset = char_offset + len(line)
-            if current_section.line_start is None:
-                current_section.line_start = line_number
-            current_section.line_end = line_number
-        char_offset += len(line) + 1
+        current_section.content += ("\n" if current_section.content else "") + line.rstrip()
+        body_lines.append(line.rstrip())
 
     sections = [section for section in sections if section.content or section.title]
     combined = "\n".join(body_lines)
     pages = [PageContent(number=1, text=combined)]
-    metadata = {"format": "markdown", "heading_count": heading_count}
+    metadata = {"format": "markdown", "heading_count": len([s for s in sections if s.title])}
     return ParsedDocument(text=combined, metadata=metadata, sections=sections, pages=pages)

--- a/app/ingest/parsers/pdf_parser.py
+++ b/app/ingest/parsers/pdf_parser.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import datetime as _dt
 from pathlib import Path
-from statistics import median
 from typing import Any
 
 from . import DocumentSection, PageContent, ParsedDocument, ParserError
@@ -44,119 +43,25 @@ def parse_pdf(path: Path) -> ParsedDocument:
         raise ParserError(str(exc)) from exc
 
     try:
-        document_lines: list[str] = []
+        texts: list[str] = []
         sections: list[DocumentSection] = []
         pages: list[PageContent] = []
         needs_ocr = True
-        heading_count = 0
-        current_section: DocumentSection | None = None
-        char_offset = 0
-        line_number = 0
 
         for index, page in enumerate(document, start=1):
-            page_dict = page.get_text("dict")
-            line_candidates: list[dict[str, Any]] = []
-            span_sizes: list[float] = []
-
-            for block in page_dict.get("blocks", []):
-                for line in block.get("lines", []):
-                    spans = line.get("spans") or []
-                    if not spans:
-                        continue
-                    raw_text = "".join(span.get("text", "") for span in spans)
-                    text_line = raw_text.rstrip()
-                    is_blank = not text_line.strip()
-                    size = 0.0
-                    bold = False
-                    if not is_blank:
-                        numeric_sizes = [
-                            float(span.get("size", 0.0))
-                            for span in spans
-                            if str(span.get("text", "")).strip()
-                        ]
-                        if numeric_sizes:
-                            size = max(numeric_sizes)
-                            span_sizes.extend(numeric_sizes)
-                        bold = any(int(span.get("flags", 0)) & 2 for span in spans)
-                    line_candidates.append(
-                        {
-                            "text": text_line,
-                            "blank": is_blank,
-                            "size": size,
-                            "bold": bold,
-                            "page": index,
-                        }
-                    )
-
-            body_size = median(span_sizes) if span_sizes else 0.0
-            page_lines: list[str] = []
-
-            for entry in line_candidates:
-                text_line = entry["text"]
-                page_lines.append(text_line)
-                document_lines.append(text_line)
-                if entry["blank"]:
-                    char_offset += len(text_line) + 1 if text_line else 1
-                    line_number += 1
-                    continue
-
-                stripped = text_line.strip()
-                if stripped:
-                    needs_ocr = False
-
-                level: int | None = None
-                if body_size and stripped:
-                    relative = entry["size"] / body_size if body_size else 1.0
-                    word_count = len(stripped.split())
-                    if relative >= 1.8 and word_count <= 20:
-                        level = 1
-                    elif relative >= 1.45 and word_count <= 24:
-                        level = 2
-                    elif relative >= 1.25 and word_count <= 28:
-                        level = 3
-                    elif entry["bold"] and relative >= 1.1 and word_count <= 20:
-                        level = 3
-
-                if level is not None:
-                    heading_count += 1
-                    current_section = DocumentSection(
-                        title=stripped,
-                        content="",
-                        level=level,
-                        page_number=index,
-                        start_offset=char_offset,
-                        end_offset=char_offset + len(text_line),
-                        line_start=line_number + 1,
-                        line_end=line_number + 1,
-                    )
-                    sections.append(current_section)
-                    char_offset += len(text_line) + 1
-                    line_number += 1
-                    continue
-
-                if current_section is None:
-                    current_section = DocumentSection(
-                        title=None,
-                        content="",
-                        level=None,
-                        page_number=index,
-                        start_offset=char_offset,
-                        line_start=line_number + 1,
-                    )
-                    sections.append(current_section)
-
-                if current_section.content:
-                    current_section.content += "\n"
-                current_section.content += text_line
-                current_section.end_offset = char_offset + len(text_line)
-                current_section.line_end = line_number + 1
-                if current_section.line_start is None:
-                    current_section.line_start = line_number + 1
-
-                char_offset += len(text_line) + 1
-                line_number += 1
-
-            pages.append(PageContent(number=index, text="\n".join(page_lines)))
+            text = page.get_text("text")
+            if text.strip():
+                needs_ocr = False
+            texts.append(text.strip())
+            sections.append(
+                DocumentSection(
+                    title=f"Page {index}",
+                    content=text.strip(),
+                    level=1,
+                    page_number=index,
+                )
+            )
+            pages.append(PageContent(number=index, text=text))
 
         metadata = {key: value for key, value in (document.metadata or {}).items() if value}
         if document.page_count is not None:
@@ -175,11 +80,10 @@ def parse_pdf(path: Path) -> ParsedDocument:
             else None
         )
 
-        sections = [section for section in sections if section.content or section.title]
-        combined_text = "\n".join(document_lines).strip()
+        combined_text = "\n\n".join(filter(None, texts))
         return ParsedDocument(
             text=combined_text,
-            metadata={**metadata, "heading_count": heading_count},
+            metadata=metadata,
             sections=sections,
             pages=pages,
             needs_ocr=needs_ocr,

--- a/app/ingest/parsers/text_parser.py
+++ b/app/ingest/parsers/text_parser.py
@@ -25,18 +25,6 @@ def parse_text(path: Path) -> ParsedDocument:
             text = raw.decode(encoding, errors="replace")
 
     metadata = {"encoding": encoding}
-    line_count = text.count("\n") + 1 if text else 0
-    sections = [
-        DocumentSection(
-            title=None,
-            content=text,
-            level=None,
-            page_number=1,
-            start_offset=0,
-            end_offset=len(text),
-            line_start=1 if line_count else None,
-            line_end=line_count if line_count else None,
-        )
-    ]
+    sections = [DocumentSection(title=None, content=text)]
     pages = [PageContent(number=1, text=text)]
     return ParsedDocument(text=text, metadata=metadata, sections=sections, pages=pages)

--- a/app/storage/database.py
+++ b/app/storage/database.py
@@ -4,21 +4,18 @@ from __future__ import annotations
 
 import contextlib
 import datetime as _dt
-import difflib
 import json
 import re
 import shutil
 import sqlite3
 import threading
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Iterable, Sequence
+from typing import TYPE_CHECKING, Any, Callable, Iterable
 
 if TYPE_CHECKING:
     from app.ingest.parsers import ParsedDocument
 
-from app.ingest.parsers import DocumentSection
-
-SCHEMA_VERSION = 5
+SCHEMA_VERSION = 4
 SCHEMA_FILENAME = "schema.sql"
 
 
@@ -80,43 +77,11 @@ class DatabaseManager:
         self._set_user_version(connection, SCHEMA_VERSION)
 
     def _apply_migrations(self, connection: sqlite3.Connection, current: int) -> None:
-        """Upgrade the schema from ``current`` to ``SCHEMA_VERSION``."""
-
-        upgraded = False
-
-        if current < 5:
-            self._migrate_to_v5(connection)
-            current = 5
-            upgraded = True
-
-        if current < SCHEMA_VERSION:
-            # Future migrations would be chained here.
-            self._install_base_schema(connection)
-            current = SCHEMA_VERSION
-
-        if upgraded or current != SCHEMA_VERSION:
-            self._set_user_version(connection, SCHEMA_VERSION)
-
-    def _migrate_to_v5(self, connection: sqlite3.Connection) -> None:
-        """Add chunk metadata storage introduced in schema version 5."""
-
-        columns = self._get_table_columns(connection, "ingest_document_chunks")
-        if "metadata" not in columns:
-            connection.execute("ALTER TABLE ingest_document_chunks ADD COLUMN metadata TEXT")
-            connection.execute(
-                "UPDATE ingest_document_chunks SET metadata = '{}' WHERE metadata IS NULL"
-            )
-
-    @staticmethod
-    def _get_table_columns(connection: sqlite3.Connection, table: str) -> list[str]:
-        rows = connection.execute(f"PRAGMA table_info({table})").fetchall()
-        columns: list[str] = []
-        for row in rows:
-            try:
-                columns.append(str(row["name"]))
-            except (IndexError, KeyError, TypeError):  # pragma: no cover - defensive
-                continue
-        return columns
+        """Placeholder for future migrations from ``current`` to ``SCHEMA_VERSION``."""
+        if current >= SCHEMA_VERSION:
+            return
+        # No incremental migrations yet; reapply schema to fill gaps.
+        self._install_base_schema(connection)
 
     @staticmethod
     def _get_user_version(connection: sqlite3.Connection) -> int:
@@ -566,12 +531,6 @@ class DocumentRepository(BaseRepository):
 class IngestDocumentRepository(BaseRepository):
     """Manage parsed document text, previews, and search indexes."""
 
-    _chunk_metadata_supported: bool | None
-
-    def __init__(self, db: DatabaseManager) -> None:
-        super().__init__(db)
-        self._chunk_metadata_supported = None
-
     def store_version(
         self,
         *,
@@ -644,8 +603,8 @@ class IngestDocumentRepository(BaseRepository):
                 connection,
                 document_id,
                 normalized_path,
-                parsed,
-                normalized_text=normalized_text,
+                parsed.text,
+                normalized_text,
             )
         return self.get(document_id)  # type: ignore[return-value]
 
@@ -723,116 +682,7 @@ class IngestDocumentRepository(BaseRepository):
         return self.search_chunks(query, limit=limit)
 
     def search_chunks(self, query: str, *, limit: int = 5) -> list[dict[str, Any]]:
-        connection = self.db.connect()
-        rows, metadata_supported = self._execute_search(connection, query, limit)
-
-        if not rows:
-            return []
-
-        document_ids = {int(row["document_id"]) for row in rows}
-        documents: dict[int, dict[str, Any]] = {}
-        for doc_id in document_ids:
-            document = self.get(doc_id)
-            if document is not None:
-                documents[doc_id] = document
-
-        results: list[dict[str, Any]] = []
-        normalized_query = (query or "").lower()
-        results: list[dict[str, Any]] = []
-        for row in rows:
-            doc_id = int(row["document_id"])
-            document = documents.get(doc_id)
-            if document is None:
-                continue
-            metadata_raw = row["metadata"] if metadata_supported else None
-            chunk_metadata = json.loads(metadata_raw) if metadata_raw else {}
-            chunk = {
-                "id": int(row["chunk_id"]),
-                "document_id": doc_id,
-                "index": int(row["chunk_index"]),
-                "text": row["chunk_text"],
-                "token_count": int(row["token_count"]),
-                "start_offset": int(row["start_offset"]),
-                "end_offset": int(row["end_offset"]),
-                "metadata": chunk_metadata,
-            }
-            chunk_metadata.setdefault("bm25", float(row["score"]))
-            hierarchy_weight = float(chunk_metadata.get("hierarchy_weight", 1.0) or 1.0)
-            raw_score = float(row["score"])
-            keyword_score = 1.0 / (1.0 + max(raw_score, 0.0))
-            semantic_score = 0.0
-            chunk_text_lower = (row["chunk_text"] or "").lower()
-            if normalized_query and chunk_text_lower:
-                matcher = difflib.SequenceMatcher(None, normalized_query, chunk_text_lower)
-                semantic_score = matcher.ratio()
-            combined_score = (0.5 * keyword_score + 0.5 * semantic_score) * hierarchy_weight
-            score_breakdown = {
-                "keyword": keyword_score,
-                "semantic": semantic_score,
-                "hierarchy_weight": hierarchy_weight,
-            }
-            results.append(
-                {
-                    "chunk": chunk,
-                    "document": document,
-                    "highlight": row["snippet"],
-                    "score": combined_score,
-                    "score_breakdown": score_breakdown,
-                    "path": document.get("path"),
-                }
-            )
-        results.sort(key=lambda item: item["score"], reverse=True)
-        return results[:limit]
-
-    def _execute_search(
-        self, connection: sqlite3.Connection, query: str, limit: int
-    ) -> tuple[list[sqlite3.Row], bool]:
-        """Execute a search query with backward compatibility for legacy schemas."""
-
-        if self._chunk_metadata_supported is False:
-            rows = self._execute_legacy_search(connection, query, limit)
-            return rows, False
-
-        try:
-            rows = connection.execute(
-                """
-                SELECT
-                    ingest_document_index.rowid AS chunk_id,
-                    ingest_document_index.document_id AS document_id,
-                    ingest_document_index.chunk_index AS chunk_index,
-                    ingest_document_index.path AS path,
-                    highlight(ingest_document_index, 0, '<mark>', '</mark>') AS snippet,
-                    bm25(ingest_document_index) AS score,
-                    chunks.text AS chunk_text,
-                    chunks.token_count AS token_count,
-                    chunks.start_offset AS start_offset,
-                    chunks.end_offset AS end_offset,
-                    chunks.metadata AS metadata
-                FROM ingest_document_index
-                INNER JOIN ingest_document_chunks AS chunks ON chunks.id = ingest_document_index.rowid
-                WHERE ingest_document_index MATCH ?
-                ORDER BY score ASC, chunk_index ASC
-                LIMIT ?
-                """,
-                (query, limit),
-            ).fetchall()
-        except sqlite3.OperationalError as exc:
-            message = str(exc).lower()
-            if "metadata" not in message:
-                raise
-            rows = self._execute_legacy_search(connection, query, limit)
-            self._chunk_metadata_supported = False
-            return rows, False
-
-        self._chunk_metadata_supported = True
-        return rows, True
-
-    def _execute_legacy_search(
-        self, connection: sqlite3.Connection, query: str, limit: int
-    ) -> list[sqlite3.Row]:
-        """Fallback search for databases without chunk metadata support."""
-
-        return connection.execute(
+        rows = self.db.connect().execute(
             """
             SELECT
                 ingest_document_index.rowid AS chunk_id,
@@ -853,6 +703,42 @@ class IngestDocumentRepository(BaseRepository):
             """,
             (query, limit),
         ).fetchall()
+
+        if not rows:
+            return []
+
+        document_ids = {int(row["document_id"]) for row in rows}
+        documents: dict[int, dict[str, Any]] = {}
+        for doc_id in document_ids:
+            document = self.get(doc_id)
+            if document is not None:
+                documents[doc_id] = document
+
+        results: list[dict[str, Any]] = []
+        for row in rows:
+            doc_id = int(row["document_id"])
+            document = documents.get(doc_id)
+            if document is None:
+                continue
+            chunk = {
+                "id": int(row["chunk_id"]),
+                "document_id": doc_id,
+                "index": int(row["chunk_index"]),
+                "text": row["chunk_text"],
+                "token_count": int(row["token_count"]),
+                "start_offset": int(row["start_offset"]),
+                "end_offset": int(row["end_offset"]),
+            }
+            results.append(
+                {
+                    "chunk": chunk,
+                    "document": document,
+                    "highlight": row["snippet"],
+                    "score": float(row["score"]),
+                    "path": document.get("path"),
+                }
+            )
+        return results
 
     @staticmethod
     def _normalize_text(text: str) -> str:
@@ -888,11 +774,10 @@ class IngestDocumentRepository(BaseRepository):
         connection: sqlite3.Connection,
         document_id: int,
         path: str,
-        parsed: "ParsedDocument",
-        *,
+        text: str,
         normalized_text: str,
     ) -> None:
-        chunks = self._semantic_chunk_document(parsed, normalized_text=normalized_text, path=path)
+        chunks = self._chunk_document(text, normalized_text=normalized_text)
         connection.execute(
             "DELETE FROM ingest_document_chunks WHERE document_id = ?",
             (document_id,),
@@ -901,9 +786,9 @@ class IngestDocumentRepository(BaseRepository):
             cursor = connection.execute(
                 """
                 INSERT INTO ingest_document_chunks (
-                    document_id, chunk_index, text, token_count, start_offset, end_offset, metadata
+                    document_id, chunk_index, text, token_count, start_offset, end_offset
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?)
                 """,
                 (
                     document_id,
@@ -912,7 +797,6 @@ class IngestDocumentRepository(BaseRepository):
                     chunk["token_count"],
                     chunk["start_offset"],
                     chunk["end_offset"],
-                    json.dumps(chunk.get("metadata", {}), ensure_ascii=False),
                 ),
             )
             chunk_id = cursor.lastrowid
@@ -933,230 +817,75 @@ class IngestDocumentRepository(BaseRepository):
                 ),
             )
 
-    def _semantic_chunk_document(
-        self,
-        parsed: "ParsedDocument",
-        *,
-        normalized_text: str,
-        path: str,
-        min_chars: int = 400,
+    def _chunk_document(
+        self, text: str, *, normalized_text: str, max_tokens: int = 200, overlap: int = 40
     ) -> list[dict[str, Any]]:
-        sections: list[DocumentSection] = list(parsed.sections or [])
-        if not sections:
-            sections = [
-                DocumentSection(
-                    title=None,
-                    content=parsed.text,
-                    level=None,
-                    page_number=1,
-                    start_offset=0,
-                    end_offset=len(parsed.text),
-                    line_start=1 if parsed.text else None,
-                    line_end=parsed.text.count("\n") + 1 if parsed.text else None,
-                )
-            ]
-
-        section_paths = self._build_section_paths(sections)
-        windows: list[list[int]] = []
-        index = 0
-        total = len(sections)
-        while index < total:
-            section = sections[index]
-            level = section.level if section.level is not None else 6
-            if section.title and level <= 3:
-                next_index = index + 1
-                while next_index < total:
-                    candidate = sections[next_index]
-                    candidate_level = candidate.level if candidate.level is not None else 6
-                    if candidate.title and candidate_level <= level:
-                        break
-                    next_index += 1
-                windows.append(list(range(index, next_index)))
-                index = next_index
-            else:
-                windows.append([index])
-                index += 1
-
-        def window_length(indices: Sequence[int]) -> int:
-            return len(self._render_sections(sections, indices))
-
-        final_windows: list[list[int]] = []
-        buffer: list[int] | None = None
-        for window in windows:
-            if buffer is None:
-                buffer = list(window)
-                continue
-            if window_length(buffer) < min_chars:
-                buffer.extend(window)
-                continue
-            final_windows.append(buffer)
-            buffer = list(window)
-
-        if buffer is not None:
-            if final_windows and window_length(buffer) < min_chars:
-                final_windows[-1].extend(buffer)
-            else:
-                final_windows.append(buffer)
-
-        if not final_windows:
-            final_windows = [[0]]
-
+        max_tokens = max(1, int(max_tokens))
+        overlap = max(0, min(int(overlap), max_tokens - 1))
+        matches = list(re.finditer(r"\S+", text))
         chunks: list[dict[str, Any]] = []
+        if not matches:
+            trimmed = text.strip()
+            chunk_text = trimmed if trimmed else normalized_text
+            chunks.append(
+                {
+                    "index": 0,
+                    "text": chunk_text,
+                    "token_count": 0,
+                    "start_offset": 0,
+                    "end_offset": len(chunk_text),
+                    "search_text": self._normalize_text(chunk_text),
+                }
+            )
+            return chunks
+
+        step = max_tokens - overlap if max_tokens > overlap else max_tokens
+        start_token = 0
         chunk_index = 0
-        for indices in final_windows:
-            chunk_text = self._render_sections(sections, indices)
-            if not chunk_text.strip():
-                continue
-            start_offset = min(
-                (sections[i].start_offset for i in indices if sections[i].start_offset is not None),
-                default=0,
-            )
-            end_offset = max(
-                (sections[i].end_offset for i in indices if sections[i].end_offset is not None),
-                default=start_offset + len(chunk_text),
-            )
-            token_count = len(chunk_text.split())
-            metadata = self._build_chunk_metadata(sections, section_paths, indices, path)
-            metadata.setdefault("token_count", token_count)
-            search_terms = " ".join(metadata.get("section_path", []))
-            search_basis = f"{search_terms} {chunk_text}" if search_terms else chunk_text
+        text_length = len(text)
+
+        while start_token < len(matches):
+            end_token = min(start_token + max_tokens, len(matches))
+            start_offset = matches[start_token].start()
+            end_offset = matches[end_token - 1].end() if end_token > start_token else start_offset
+            if end_token >= len(matches):
+                end_offset = text_length
+            chunk_text = text[start_offset:end_offset].strip()
+            if not chunk_text:
+                if chunks:
+                    start_token += step
+                    chunk_index += 1
+                    continue
+                chunk_text = normalized_text
+            search_text = self._normalize_text(chunk_text)
             chunks.append(
                 {
                     "index": chunk_index,
                     "text": chunk_text,
-                    "token_count": token_count,
+                    "token_count": end_token - start_token,
                     "start_offset": start_offset,
                     "end_offset": end_offset,
-                    "search_text": self._normalize_text(search_basis or normalized_text),
-                    "metadata": metadata,
+                    "search_text": search_text,
                 }
             )
+            if end_token >= len(matches):
+                break
+            start_token += step
             chunk_index += 1
 
         if not chunks:
+            chunk_text = normalized_text
             chunks.append(
                 {
                     "index": 0,
-                    "text": parsed.text or normalized_text,
-                    "token_count": len((parsed.text or "").split()),
+                    "text": chunk_text,
+                    "token_count": len(matches),
                     "start_offset": 0,
-                    "end_offset": len(parsed.text or normalized_text),
-                    "search_text": self._normalize_text(parsed.text or normalized_text),
-                    "metadata": {
-                        "section_path": [],
-                        "sections": [],
-                        "hierarchy_weight": 1.0,
-                        "source_path": path,
-                    },
+                    "end_offset": len(chunk_text),
+                    "search_text": self._normalize_text(chunk_text),
                 }
             )
         return chunks
-
-    @staticmethod
-    def _build_section_paths(sections: Sequence[DocumentSection]) -> list[list[str]]:
-        paths: list[list[str]] = []
-        stack: list[tuple[int, str]] = []
-        for section in sections:
-            level = section.level if section.level is not None else 6
-            if section.title:
-                while stack and stack[-1][0] >= level:
-                    stack.pop()
-                stack.append((level, section.title))
-            paths.append([title for _, title in stack])
-        return paths
-
-    @staticmethod
-    def _render_sections(
-        sections: Sequence[DocumentSection], indices: Sequence[int]
-    ) -> str:
-        parts: list[str] = []
-        for index in indices:
-            section = sections[index]
-            local_parts: list[str] = []
-            if section.title:
-                level = section.level if section.level and section.level > 0 else 1
-                prefix = "#" * min(level, 6)
-                header = f"{prefix} {section.title}" if prefix else section.title
-                local_parts.append(header.strip())
-            if section.content:
-                local_parts.append(section.content.strip("\n"))
-            if local_parts:
-                parts.append("\n".join(local_parts))
-        return "\n\n".join(parts).strip()
-
-    def _build_chunk_metadata(
-        self,
-        sections: Sequence[DocumentSection],
-        section_paths: Sequence[Sequence[str]],
-        indices: Sequence[int],
-        source_path: str,
-    ) -> dict[str, Any]:
-        first_idx = indices[0]
-        path = list(section_paths[first_idx])
-        hierarchy_weight = self._hierarchy_weight(path)
-        page_numbers = [
-            sections[i].page_number for i in indices if sections[i].page_number is not None
-        ]
-        line_start = min(
-            (sections[i].line_start for i in indices if sections[i].line_start is not None),
-            default=None,
-        )
-        line_end = max(
-            (sections[i].line_end for i in indices if sections[i].line_end is not None),
-            default=None,
-        )
-        start_offset = min(
-            (sections[i].start_offset for i in indices if sections[i].start_offset is not None),
-            default=None,
-        )
-        end_offset = max(
-            (sections[i].end_offset for i in indices if sections[i].end_offset is not None),
-            default=None,
-        )
-        section_summaries = [
-            {
-                "index": i,
-                "title": sections[i].title,
-                "level": sections[i].level,
-                "path": list(section_paths[i]),
-                "page": sections[i].page_number,
-                "line_start": sections[i].line_start,
-                "line_end": sections[i].line_end,
-            }
-            for i in indices
-        ]
-        return {
-            "section_path": path,
-            "sections": section_summaries,
-            "hierarchy_weight": hierarchy_weight,
-            "page_range": {
-                "start": min(page_numbers) if page_numbers else None,
-                "end": max(page_numbers) if page_numbers else None,
-            },
-            "position": {
-                "start_offset": start_offset,
-                "end_offset": end_offset,
-                "line_start": line_start,
-                "line_end": line_end,
-            },
-            "source_path": source_path,
-        }
-
-    @staticmethod
-    def _hierarchy_weight(path: Sequence[str]) -> float:
-        if not path:
-            return 1.0
-        title = path[-1].lower()
-        if any(keyword in title for keyword in ("appendix", "annex", "supplement")):
-            base = 0.6
-        elif any(keyword in title for keyword in ("reference", "bibliography")):
-            base = 0.7
-        elif any(keyword in title for keyword in ("abstract", "summary")):
-            base = 0.85
-        else:
-            base = 1.0
-        depth_penalty = min(0.05 * max(len(path) - 1, 0), 0.25)
-        return max(0.4, base - depth_penalty)
 
     @staticmethod
     def _build_preview(text: str, *, limit: int = 320) -> str:

--- a/app/storage/schema.sql
+++ b/app/storage/schema.sql
@@ -176,7 +176,6 @@ CREATE TABLE IF NOT EXISTS ingest_document_chunks (
     token_count INTEGER NOT NULL,
     start_offset INTEGER NOT NULL,
     end_offset INTEGER NOT NULL,
-    metadata TEXT,
     created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
     UNIQUE(document_id, chunk_index),
     FOREIGN KEY (document_id) REFERENCES ingest_documents(id) ON DELETE CASCADE

--- a/tests/test_parser_file_types.py
+++ b/tests/test_parser_file_types.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from app.ingest.parsers import parse_file
+from app.ingest.parsers import SUPPORTED_SUFFIXES, parse_file
 
 
 def test_parse_file_supports_code_and_markup(tmp_path: Path) -> None:
@@ -21,3 +21,8 @@ def test_parse_file_supports_code_and_markup(tmp_path: Path) -> None:
 
         assert content.strip().splitlines()[0] in parsed.text
         assert parsed.metadata["encoding"].lower() == "utf-8"
+
+
+def test_supported_suffixes_include_code_extensions() -> None:
+    for suffix in (".m", ".py", ".cpp"):
+        assert suffix in SUPPORTED_SUFFIXES


### PR DESCRIPTION
## Summary
- revert the context-aware chunking implementation and associated parser metadata changes
- remove the ingest chunk metadata storage additions and simplify ingestion queries
- update tests to reflect the restored ingestion behavior
- ensure code file extensions (.m, .py, .cpp) are parsed via the text parser and covered by regression tests

## Testing
- PYTHONPATH=. pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68db6161634883229316ede101c3ce5c