### PR TITLE
Add coverage for conversation context injection and chunking strategies

### DIFF
--- a/tests/test_conversation_manager.py
+++ b/tests/test_conversation_manager.py
@@ -19,6 +19,28 @@ from app.services.conversation_manager import (
 )
 
 
+def test_build_messages_appends_context_snippets_to_user_prompt() -> None:
+    manager = object.__new__(ConversationManager)
+    manager.system_prompt = "System instructions"
+    manager.turns = []
+    manager.context_window = 0
+
+    messages = manager._build_messages(
+        "Summarise the findings",
+        [
+            "Doc1: Important discovery",
+            "Doc2: Follow-up validation",
+        ],
+    )
+
+    assert messages[0] == {"role": "system", "content": "System instructions"}
+    assert messages[-1]["role"] == "user"
+    assert messages[-1]["content"].startswith("Summarise the findings")
+    assert "Context:\nDoc1: Important discovery\n\nDoc2: Follow-up validation" in messages[-1][
+        "content"
+    ]
+
+
 def test_ensure_answer_citation_markers_aligns_citations_with_sentences():
     answer = "Alpha result shows improvement. Beta data remains flat."
     citations = [


### PR DESCRIPTION
## Summary
- add a regression test to ensure conversation messages include retrieved corpus context when sent to the LLM
- extend storage tests to validate chunking behaviour for code and HTML inputs across different suffixes

## Testing
- pytest tests/test_conversation_manager.py::test_build_messages_appends_context_snippets_to_user_prompt tests/test_storage.py::test_chunk_document_aligns_code_chunks_to_line_start tests/test_storage.py::test_chunk_document_aligns_html_chunks_to_tag_boundaries

------
https://chatgpt.com/codex/tasks/task_e_68dbf1e984f88322b5935a828a754c3c