### PR TITLE
Add comprehensive logging across core services

### DIFF
--- a/app/__main__.py
+++ b/app/__main__.py
@@ -27,6 +27,7 @@ def main() -> None:
     app = QApplication(sys.argv)
     app.setApplicationName("DataMiner")
 
+    logger.info("Initialising core services")
     settings_service = SettingsService()
     progress_service = ProgressService()
     lmstudio_client = LMStudioClient()
@@ -35,6 +36,21 @@ def main() -> None:
     document_hierarchy = DocumentHierarchyService(project_service.documents)
     export_service = ExportService()
     backup_service = BackupService(project_service)
+    logger.debug(
+        "Service graph ready",
+        extra={
+            "services": [
+                "SettingsService",
+                "ProgressService",
+                "LMStudioClient",
+                "ProjectService",
+                "IngestService",
+                "DocumentHierarchyService",
+                "ExportService",
+                "BackupService",
+            ]
+        },
+    )
 
     window = MainWindow(
         settings_service=settings_service,
@@ -47,13 +63,17 @@ def main() -> None:
         backup_service=backup_service,
     )
     window.show()
+    logger.info("Main window shown")
 
     logger.info("Application started")
     try:
         exit_code = app.exec()
+        logger.info("Application event loop exited", extra={"exit_code": exit_code})
     finally:
+        logger.info("Commencing shutdown sequence")
         ingest_service.shutdown(wait=False)
         project_service.shutdown()
+        logger.info("Shutdown complete")
     sys.exit(exit_code)
 
 

--- a/app/services/document_hierarchy.py
+++ b/app/services/document_hierarchy.py
@@ -2,18 +2,26 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Any, Iterable
 
 from app.storage import DocumentRepository
 
+from ..logging import log_call
+
+
+logger = logging.getLogger(__name__)
+
 
 class DocumentHierarchyService:
     """Provide hierarchical views of documents for the UI layer."""
 
+    @log_call(logger=logger)
     def __init__(self, documents: DocumentRepository) -> None:
         self.documents = documents
 
+    @log_call(logger=logger, include_result=True)
     def build_folder_tree(self, project_id: int) -> dict[str, Any]:
         """Return a nested folder tree with documents attached at each node."""
 
@@ -34,8 +42,17 @@ class DocumentHierarchyService:
                     index[ancestor] = node
             index[relative]["documents"].append(document)
         self._sort_tree(root)
+        logger.info(
+            "Built folder tree",
+            extra={
+                "project_id": project_id,
+                "document_count": len(documents),
+                "node_count": len(index),
+            },
+        )
         return root
 
+    @log_call(logger=logger, include_result=True)
     def list_documents_for_scope(
         self,
         project_id: int,
@@ -54,6 +71,7 @@ class DocumentHierarchyService:
         )
         return [self._with_tags(document) for document in documents]
 
+    @log_call(logger=logger, include_result=True)
     def get_document_view(self, document_id: int) -> dict[str, Any] | None:
         """Return a metadata view for ``document_id`` including its tags."""
 
@@ -62,18 +80,21 @@ class DocumentHierarchyService:
             return None
         return self._with_tags(document)
 
+    @log_call(logger=logger)
     def refresh_tag_counts(self, project_id: int | None = None) -> None:
         """Recalculate tag counts via the repository helper."""
 
         self.documents.refresh_tag_counts(project_id)
 
     @staticmethod
+    @log_call(logger=logger, include_result=True)
     def _normalize_folder(folder: Any) -> str | None:
         if folder in (None, ""):
             return None
         return str(Path(folder))
 
     @staticmethod
+    @log_call(logger=logger, include_result=True)
     def _relative_folder(folder: str | None, base_path: Path | None) -> str | None:
         if folder is None:
             return None
@@ -88,6 +109,7 @@ class DocumentHierarchyService:
         return None if relative_str in ("", ".") else relative_str
 
     @staticmethod
+    @log_call(logger=logger, include_result=True)
     def _absolute_path(base_path: Path | None, relative: str | None) -> str | None:
         if relative in (None, ""):
             return str(base_path) if base_path is not None else None
@@ -96,6 +118,7 @@ class DocumentHierarchyService:
         return str((base_path / relative))
 
     @staticmethod
+    @log_call(logger=logger, include_result=True)
     def _node_name(path: str | None) -> str:
         if path is None:
             return ""
@@ -103,10 +126,12 @@ class DocumentHierarchyService:
         return name or str(Path(path))
 
     @staticmethod
+    @log_call(logger=logger, include_result=True)
     def _create_node(*, name: str, path: str | None) -> dict[str, Any]:
         return {"name": name, "path": path, "documents": [], "children": []}
 
     @staticmethod
+    @log_call(logger=logger, include_result=True)
     def _parent_folder_key(path: str | None) -> str | None:
         if path in (None, "", "."):
             return None
@@ -118,6 +143,7 @@ class DocumentHierarchyService:
         return parent_str
 
     @staticmethod
+    @log_call(logger=logger, include_result=True)
     def _iter_folder_paths(folder: str | None) -> Iterable[str | None]:
         yield None
         if folder in (None, "", "."):
@@ -136,6 +162,7 @@ class DocumentHierarchyService:
             yield str(ancestor)
 
     @staticmethod
+    @log_call(logger=logger, include_result=True)
     def _determine_base_path(documents: Iterable[dict[str, Any]]) -> Path | None:
         folders = [Path(doc["folder_path"]) for doc in documents if doc.get("folder_path")]
         if not folders:
@@ -148,11 +175,13 @@ class DocumentHierarchyService:
                     break
         return base
 
+    @log_call(logger=logger, include_result=True)
     def _with_tags(self, document: dict[str, Any]) -> dict[str, Any]:
         enriched = dict(document)
         enriched["tags"] = self.documents.list_tags_for_document(document["id"])
         return enriched
 
+    @log_call(logger=logger)
     def _sort_tree(self, node: dict[str, Any]) -> None:
         node["documents"].sort(key=lambda item: (item.get("title") or "").lower())
         children = node["children"]

--- a/app/services/export_service.py
+++ b/app/services/export_service.py
@@ -5,16 +5,22 @@ from __future__ import annotations
 import datetime as _dt
 import html
 import json
+import logging
 import textwrap
 from pathlib import Path
 from typing import Iterable, Sequence
 
 from .conversation_manager import ConversationTurn
+from ..logging import log_call
+
+
+logger = logging.getLogger(__name__)
 
 
 class ExportService:
     """Render conversation history or snippets to export-friendly formats."""
 
+    @log_call(logger=logger, include_result=True)
     def conversation_to_markdown(
         self,
         turns: Sequence[ConversationTurn] | Iterable[ConversationTurn],
@@ -34,6 +40,7 @@ class ExportService:
             lines.extend(self._turn_to_markdown(turn, index))
         return "\n".join(lines).strip() + "\n"
 
+    @log_call(logger=logger, include_result=True)
     def conversation_to_html(
         self,
         turns: Sequence[ConversationTurn] | Iterable[ConversationTurn],
@@ -77,6 +84,7 @@ class ExportService:
         parts.append("  </body>\n</html>")
         return "\n".join(parts)
 
+    @log_call(logger=logger, include_result=True)
     def snippets_to_text(self, snippets: Iterable[dict | str]) -> str:
         lines: list[str] = []
         for snippet in snippets:
@@ -94,13 +102,16 @@ class ExportService:
             lines.append(text.strip())
         return "\n\n".join(line for line in lines if line)
 
+    @log_call(logger=logger, include_result=True)
     def write_text(self, destination: str | Path, content: str) -> Path:
         path = Path(destination)
         if not path.parent.exists():
             path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(content, encoding="utf-8")
+        logger.info("Wrote export", extra={"destination": str(path), "bytes": path.stat().st_size})
         return path
 
+    @log_call(logger=logger, include_result=True)
     def export_conversation_markdown(
         self,
         destination: str | Path,
@@ -112,6 +123,7 @@ class ExportService:
         content = self.conversation_to_markdown(turns, title=title, metadata=metadata)
         return self.write_text(destination, content)
 
+    @log_call(logger=logger, include_result=True)
     def export_conversation_html(
         self,
         destination: str | Path,
@@ -123,6 +135,7 @@ class ExportService:
         content = self.conversation_to_html(turns, title=title, metadata=metadata)
         return self.write_text(destination, content)
 
+    @log_call(logger=logger, include_result=True)
     def export_snippets_text(
         self, destination: str | Path, snippets: Iterable[dict | str]
     ) -> Path:
@@ -130,6 +143,7 @@ class ExportService:
         return self.write_text(destination, content)
 
     # ------------------------------------------------------------------
+    @log_call(logger=logger, include_result=True)
     def _turn_to_markdown(self, turn: ConversationTurn, index: int) -> list[str]:
         asked = turn.asked_at.isoformat() if turn.asked_at else "—"
         answered = turn.answered_at.isoformat() if turn.answered_at else "—"
@@ -163,6 +177,7 @@ class ExportService:
         lines.extend(textwrap.indent(token_json or "{}", "    ").splitlines())
         return lines
 
+    @log_call(logger=logger, include_result=True)
     def _turn_to_html(self, turn: ConversationTurn, index: int) -> str:
         asked = html.escape(turn.asked_at.isoformat()) if turn.asked_at else "—"
         answered = html.escape(turn.answered_at.isoformat()) if turn.answered_at else "—"
@@ -191,6 +206,7 @@ class ExportService:
         )
         return "\n".join(sections)
 
+    @log_call(logger=logger, include_result=True)
     def _format_reasoning_markdown(self, turn: ConversationTurn) -> list[str]:
         lines: list[str] = []
         if turn.reasoning_bullets:
@@ -224,6 +240,7 @@ class ExportService:
                 lines.append(f"- Notes: {self_check.notes}")
         return lines
 
+    @log_call(logger=logger, include_result=True)
     def _format_reasoning_html(self, turn: ConversationTurn) -> str:
         sections: list[str] = []
         if turn.reasoning_bullets:
@@ -271,6 +288,7 @@ class ExportService:
         return "".join(sections)
 
     @staticmethod
+    @log_call(logger=logger, include_result=True)
     def _format_citation_text(citation: object) -> str:
         if isinstance(citation, str):
             return citation
@@ -293,6 +311,7 @@ class ExportService:
         return str(citation)
 
     @staticmethod
+    @log_call(logger=logger, include_result=True)
     def _strip_html(value: str | None) -> str:
         if not value:
             return ""

--- a/app/services/settings_service.py
+++ b/app/services/settings_service.py
@@ -11,6 +11,7 @@ from PyQt6.QtGui import QFont, QColor, QPalette
 from PyQt6.QtWidgets import QApplication
 
 from ..config import ConfigManager
+from ..logging import log_call
 
 
 logger = logging.getLogger(__name__)
@@ -23,6 +24,7 @@ MIN_FONT_SCALE = 0.5
 MAX_FONT_SCALE = 2.5
 
 
+@log_call(logger=logger, include_result=True)
 def _clamp(value: float, *, low: float, high: float) -> float:
     return float(min(high, max(low, value)))
 
@@ -46,6 +48,7 @@ class SettingsService(QObject):
     font_scale_changed = pyqtSignal(float)
     density_changed = pyqtSignal(str)
 
+    @log_call(logger=logger)
     def __init__(self, config_manager: ConfigManager | None = None) -> None:
         super().__init__()
         self._config = config_manager or ConfigManager()
@@ -55,6 +58,7 @@ class SettingsService(QObject):
 
     # ------------------------------------------------------------------
     # Persistence helpers
+    @log_call(logger=logger)
     def reload(self) -> None:
         """Reload settings from disk."""
 
@@ -97,6 +101,7 @@ class SettingsService(QObject):
         )
         self._base_font_point_size = None
 
+    @log_call(logger=logger)
     def save(self) -> None:
         """Persist the current settings to disk."""
 
@@ -147,6 +152,7 @@ class SettingsService(QObject):
 
     # ------------------------------------------------------------------
     # Mutators
+    @log_call(logger=logger)
     def set_theme(self, theme: str) -> None:
         normalized = "dark" if str(theme).lower() == "dark" else "light"
         if normalized == self._settings.theme:
@@ -156,9 +162,11 @@ class SettingsService(QObject):
         logger.info("Theme changed", extra={"theme": normalized})
         self.theme_changed.emit(normalized)
 
+    @log_call(logger=logger)
     def toggle_theme(self) -> None:
         self.set_theme("dark" if self._settings.theme == "light" else "light")
 
+    @log_call(logger=logger)
     def set_font_scale(self, scale: float) -> None:
         try:
             value = float(scale)
@@ -172,6 +180,7 @@ class SettingsService(QObject):
         logger.info("Font scale changed", extra={"font_scale": value})
         self.font_scale_changed.emit(value)
 
+    @log_call(logger=logger)
     def set_density(self, density: str) -> None:
         normalized = str(density).lower()
         if normalized not in {"compact", "comfortable"}:
@@ -183,6 +192,7 @@ class SettingsService(QObject):
         logger.info("Density changed", extra={"density": normalized})
         self.density_changed.emit(normalized)
 
+    @log_call(logger=logger)
     def set_splitter_sizes(self, sizes: Iterable[int]) -> None:
         values = [int(max(80, value)) for value in sizes]
         if len(values) != 3:
@@ -192,6 +202,7 @@ class SettingsService(QObject):
         self._settings.splitter_sizes = tuple(values)
         self.save()
 
+    @log_call(logger=logger)
     def set_show_corpus_panel(self, visible: bool) -> None:
         value = bool(visible)
         if value == self._settings.show_corpus_panel:
@@ -199,6 +210,7 @@ class SettingsService(QObject):
         self._settings.show_corpus_panel = value
         self.save()
 
+    @log_call(logger=logger)
     def set_show_evidence_panel(self, visible: bool) -> None:
         value = bool(visible)
         if value == self._settings.show_evidence_panel:


### PR DESCRIPTION
## Summary
- add a reusable `log_call` decorator and runtime environment metadata to the logging utilities so every instrumented call is traced
- instrument the application entrypoint and core services (ingest, projects, settings, backups, exports, LMStudio, document hierarchy, progress) with detailed logging for lifecycle, actions, and error handling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc0f3de9748322b812372d7bab6a2b