### PR TITLE
Normalize requirement references in conversation citation stripping

### DIFF
--- a/app/services/conversation_manager.py
+++ b/app/services/conversation_manager.py
@@ -2836,7 +2836,7 @@ class ConversationManager:
                 return ""
             lowered = content.lower()
             lowered = re.sub(
-                r"(?:doc\s*-?\d+|doc\d+|chunk\s*\d+|section\s*\d+|snippet\s*\d+|source\s*\d+)",
+                r"(?:doc\s*-?\d+|doc\d+|chunk\s*\d+|section\s*\d+|snippet\s*\d+|source\s*\d+|r(?:eq)?\s*-?(?:\d+[\da-z]*))",
                 "",
                 lowered,
             )

--- a/tests/test_conversation_manager.py
+++ b/tests/test_conversation_manager.py
@@ -77,6 +77,16 @@ def test_ensure_answer_citation_markers_handles_bullet_lists():
     assert cited == "- First finding [1]\n- Second finding [2]"
 
 
+def test_strip_citation_markers_removes_doc_and_requirement_references() -> None:
+    text = "Handles example (DOC23 chunk 1, DOC21 R-021)."
+
+    cleaned = ConversationManager._strip_citation_markers(text)
+
+    assert cleaned == "Handles example ."
+    assert "DOC" not in cleaned
+    assert "R-021" not in cleaned
+
+
 def test_context_document_to_citation_expands_snippet_to_sentence() -> None:
     document = {
         "id": "doc-1",


### PR DESCRIPTION
## Summary
- broaden the citation stripping regex so DOC and requirement identifiers are treated as metadata rather than rendered text
- add a regression test covering requirement-coded document references

## Testing
- pytest tests/test_conversation_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68dd8fa9df4c8322b99160b7b32e5caf