### PR TITLE
Store project data alongside corpus roots

### DIFF
--- a/tests/test_project_service.py
+++ b/tests/test_project_service.py
@@ -42,7 +42,7 @@ def test_corpus_root_management(tmp_path: Path) -> None:
         storage_path = service.get_project_storage(project.id)
         assert storage_path.exists()
         assert storage_path.parent.name == "projects"
-        assert storage_path.parent.parent.name == ".dataminer"
+        assert storage_path.parent.parent.name == "DataMiner"
         assert storage_path.parent.parent.parent == first.resolve()
         snapshot_path = storage_path / "dataminer.db"
         assert snapshot_path.exists()


### PR DESCRIPTION
## Summary
- default project storage directories to a visible `DataMiner/projects/<id>` folder inside the active corpus
- migrate existing hidden `.dataminer` project data into the new corpus-aligned location when encountered
- update project service tests to cover the new directory structure

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de86e17b4c83228178cae6fbe3da9d