### PR TITLE
Restore AnswerView cards alias

### DIFF
--- a/app/ui/answer_view.py
+++ b/app/ui/answer_view.py
@@ -887,6 +887,11 @@ class AnswerView(QScrollArea):
     def turns(self) -> list[ChatTurnWidget]:
         return list(self._turns)
 
+    @property
+    def cards(self) -> list[ChatTurnWidget]:
+        """Compatibility alias for legacy code that expects chat cards."""
+        return self.turns
+
     def clear(self) -> None:
         for turn in self._turns:
             turn.setParent(None)


### PR DESCRIPTION
## Summary
- restore the `cards` property on `AnswerView` as a compatibility alias for existing code that expects chat cards

## Testing
- pytest tests/test_ui_main_window.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e47653b3d88322bfd182f55e367b5a