### PR TITLE
Add font customization controls and improve settings dialog UX

### DIFF
--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -1428,6 +1428,8 @@ class MainWindow(QMainWindow):
     def _connect_services(self) -> None:
         self.settings_service.theme_changed.connect(self._apply_theme)
         self.settings_service.font_scale_changed.connect(self._apply_font_scale)
+        self.settings_service.font_family_changed.connect(self._apply_font_scale)
+        self.settings_service.font_point_size_changed.connect(self._apply_font_scale)
         self.settings_service.density_changed.connect(self._apply_density)
         self.settings_service.chat_style_changed.connect(self._on_chat_style_changed)
         self.progress_service.progress_started.connect(self._on_progress_started)
@@ -1874,7 +1876,7 @@ class MainWindow(QMainWindow):
         self.settings_service.apply_theme()
         self._show_toast(f"Theme set to {theme.title()}.", level="info", duration_ms=1500)
 
-    def _apply_font_scale(self, _scale: float) -> None:
+    def _apply_font_scale(self, *_args: object) -> None:
         self.settings_service.apply_font_scale()
 
     def _on_model_changed(self, name: str) -> None:

--- a/app/ui/settings_dialog.py
+++ b/app/ui/settings_dialog.py
@@ -5,15 +5,18 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from PyQt6.QtCore import Qt
-from PyQt6.QtGui import QColor
+from PyQt6.QtGui import QColor, QFont
 from PyQt6.QtWidgets import (
     QDialog,
     QDialogButtonBox,
+    QDoubleSpinBox,
     QFormLayout,
+    QFontComboBox,
     QGroupBox,
     QHBoxLayout,
     QLabel,
     QPushButton,
+    QFrame,
     QVBoxLayout,
     QColorDialog,
 )
@@ -76,10 +79,15 @@ class SettingsDialog(QDialog):
         self.setModal(True)
         self._settings = settings_service
         self._swatches: dict[str, ColorSwatchButton] = {}
+        self._font_combo: QFontComboBox | None = None
+        self._font_size_spin: QDoubleSpinBox | None = None
+        self._preview_label: QLabel | None = None
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(16, 16, 16, 16)
         layout.setSpacing(16)
+
+        layout.addWidget(self._build_typography_group())
 
         chat_group = QGroupBox("Chat style", self)
         chat_layout = QFormLayout(chat_group)
@@ -110,6 +118,70 @@ class SettingsDialog(QDialog):
         layout.addWidget(buttons)
 
         self._settings.chat_style_changed.connect(self._on_chat_style_changed)
+        self._settings.font_family_changed.connect(self._sync_font_family)
+        self._settings.font_point_size_changed.connect(self._sync_font_point_size)
+        self._settings.font_scale_changed.connect(self._update_font_preview)
+
+        self._sync_font_family(self._settings.font_family)
+        self._sync_font_point_size(self._settings.font_point_size)
+
+    # ------------------------------------------------------------------
+    def _build_typography_group(self) -> QGroupBox:
+        group = QGroupBox("Typography", self)
+        group_layout = QVBoxLayout(group)
+        group_layout.setSpacing(12)
+
+        form_layout = QFormLayout()
+        form_layout.setSpacing(12)
+        form_layout.setLabelAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter)
+
+        self._font_combo = QFontComboBox(group)
+        self._font_combo.setEditable(False)
+        self._font_combo.setToolTip("Choose the font family used throughout the interface.")
+        self._font_combo.currentFontChanged.connect(self._on_font_family_selected)
+        form_layout.addRow(QLabel("Font family", group), self._font_combo)
+
+        self._font_size_spin = QDoubleSpinBox(group)
+        self._font_size_spin.setRange(0.0, 48.0)
+        self._font_size_spin.setDecimals(1)
+        self._font_size_spin.setSingleStep(0.5)
+        self._font_size_spin.setSuffix(" pt")
+        self._font_size_spin.setSpecialValueText("System default")
+        self._font_size_spin.setToolTip(
+            "Specify an absolute base font size, or choose the system default by selecting 0."
+        )
+        self._font_size_spin.valueChanged.connect(self._on_font_point_size_changed)
+        form_layout.addRow(QLabel("Font size", group), self._font_size_spin)
+
+        group_layout.addLayout(form_layout)
+
+        button_row = QHBoxLayout()
+        button_row.setContentsMargins(0, 0, 0, 0)
+        reset_button = QPushButton("Reset to defaults", group)
+        reset_button.setAutoDefault(False)
+        reset_button.setToolTip("Restore the application font family and size.")
+        reset_button.clicked.connect(self._reset_font_preferences)
+        button_row.addWidget(reset_button)
+        button_row.addStretch(1)
+        group_layout.addLayout(button_row)
+
+        preview_caption = QLabel("Preview", group)
+        preview_caption.setObjectName("fontPreviewCaption")
+        group_layout.addWidget(preview_caption)
+
+        preview_frame = QFrame(group)
+        preview_frame.setFrameShape(QFrame.Shape.StyledPanel)
+        preview_frame.setFrameShadow(QFrame.Shadow.Plain)
+        preview_layout = QVBoxLayout(preview_frame)
+        preview_layout.setContentsMargins(12, 8, 12, 8)
+        self._preview_label = QLabel(
+            "The quick brown fox jumps over the lazy dog. 1234567890", preview_frame
+        )
+        self._preview_label.setWordWrap(True)
+        preview_layout.addWidget(self._preview_label)
+        group_layout.addWidget(preview_frame)
+
+        return group
 
     # ------------------------------------------------------------------
     def _choose_color(self, attribute: str) -> None:
@@ -124,6 +196,60 @@ class SettingsDialog(QDialog):
     def _on_chat_style_changed(self, style: ChatStyleSettings) -> None:  # pragma: no cover - UI update
         for attribute, swatch in self._swatches.items():
             swatch.set_color(getattr(style, attribute))
+
+    def _on_font_family_selected(self, font: QFont) -> None:
+        self._settings.set_font_preferences(family=font.family())
+
+    def _on_font_point_size_changed(self, value: float) -> None:
+        if value <= 0:
+            self._settings.set_font_preferences(point_size=None)
+        else:
+            self._settings.set_font_preferences(point_size=value)
+
+    def _reset_font_preferences(self) -> None:
+        self._settings.set_font_preferences(family=None, point_size=None)
+
+    def _sync_font_family(self, family: str | None) -> None:
+        if not self._font_combo:
+            return
+        target_family = family or QFont().defaultFamily()
+        current_family = self._font_combo.currentFont().family()
+        if current_family != target_family:
+            index = self._font_combo.findText(target_family, Qt.MatchFlag.MatchExactly)
+            self._font_combo.blockSignals(True)
+            if index >= 0:
+                self._font_combo.setCurrentIndex(index)
+            else:
+                self._font_combo.setCurrentFont(QFont(target_family))
+            self._font_combo.blockSignals(False)
+        self._update_font_preview()
+
+    def _sync_font_point_size(self, size: float | None) -> None:
+        if not self._font_size_spin:
+            return
+        target = float(size) if size and size > 0 else 0.0
+        if abs(self._font_size_spin.value() - target) > 1e-3:
+            self._font_size_spin.blockSignals(True)
+            self._font_size_spin.setValue(target)
+            self._font_size_spin.blockSignals(False)
+        self._update_font_preview()
+
+    def _update_font_preview(self, *_args: object) -> None:
+        if not (self._preview_label and self._font_combo and self._font_size_spin):
+            return
+        font = QFont(self._font_combo.currentFont())
+        point_size = self._font_size_spin.value()
+        if point_size <= 0:
+            base_size = font.pointSizeF()
+            if base_size <= 0:
+                base_size = float(font.pointSize())
+            if base_size <= 0:
+                base_size = 10.0
+        else:
+            base_size = point_size
+        scaled_size = base_size * self._settings.font_scale
+        font.setPointSizeF(scaled_size)
+        self._preview_label.setFont(font)
 
 
 __all__ = ["SettingsDialog"]

--- a/tests/test_ui_main_window.py
+++ b/tests/test_ui_main_window.py
@@ -14,6 +14,7 @@ pytest.importorskip(
 )
 
 from PyQt6.QtCore import QUrl
+from PyQt6.QtGui import QFont
 from PyQt6.QtWidgets import QApplication, QSplitter, QPushButton
 
 from app.config import ConfigManager
@@ -198,10 +199,14 @@ def test_settings_persist_theme_and_font(tmp_path, monkeypatch):
     settings_service = build_settings_service(tmp_path, monkeypatch)
     settings_service.set_theme("dark")
     settings_service.set_font_scale(1.5)
+    default_family = QFont().defaultFamily()
+    settings_service.set_font_preferences(family=default_family, point_size=14.0)
 
     reloaded = build_settings_service(tmp_path, monkeypatch)
     assert reloaded.theme == "dark"
     assert reloaded.font_scale == pytest.approx(1.5)
+    assert reloaded.font_family == default_family
+    assert reloaded.font_point_size == pytest.approx(14.0)
 
 
 def test_submission_flow_and_controls(qt_app, tmp_path, monkeypatch, project_service):


### PR DESCRIPTION
## Summary
- persist font family and point size preferences alongside the existing font scale and apply them to the Qt application fonts
- expose typography controls with reset and live preview in the settings dialog while wiring main window updates to font changes
- cover the new font persistence behaviour in the UI settings test suite

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e47d60a0f08322bc79f268e0417113