### PR TITLE
Fix missing inline citation links when answers include bracketed words

### DIFF
--- a/app/services/conversation_manager.py
+++ b/app/services/conversation_manager.py
@@ -2500,7 +2500,7 @@ class ConversationManager:
         if not answer or not citations:
             return answer
 
-        if ConversationManager._CITATION_PATTERN.search(answer):
+        if ConversationManager._NUMERIC_CITATION_PATTERN.search(answer):
             return answer
 
         fragments: list[dict[str, Any]] = []
@@ -2806,6 +2806,7 @@ class ConversationManager:
         }
         return sorted(indexes)
 
+    _NUMERIC_CITATION_PATTERN = re.compile(r"\[(\d+)\]")
     _CITATION_PATTERN = re.compile(r"\[(?:\d+|[a-zA-Z]+)\]")
     _DOC_REFERENCE_PAREN_PATTERN = re.compile(r"\(([^()]*)\)")
     _SENTENCE_FRAGMENT_PATTERN = re.compile(r"[^.!?\n]+[.!?]?")

--- a/tests/test_conversation_manager.py
+++ b/tests/test_conversation_manager.py
@@ -77,6 +77,22 @@ def test_ensure_answer_citation_markers_handles_bullet_lists():
     assert cited == "- First finding [1]\n- Second finding [2]"
 
 
+def test_ensure_answer_citation_markers_ignores_bracketed_words() -> None:
+    answer = "Key point references NASA [NASA]."
+    citations = [
+        {
+            "id": "doc-1",
+            "snippet": "<mark>Key point references NASA</mark> with context.",
+        }
+    ]
+
+    cited = ConversationManager._ensure_answer_citation_markers(answer, citations)
+
+    assert cited.endswith("[1]")
+    assert cited.count("[1]") == 1
+    assert "[NASA]" in cited
+
+
 def test_strip_citation_markers_removes_doc_and_requirement_references() -> None:
     text = "Handles example (DOC23 chunk 1, DOC21 R-021)."
 


### PR DESCRIPTION
## Summary
- ensure conversation_manager only treats numeric brackets as existing citation markers so auto-tagging still runs when answers include other bracketed text
- add a regression test covering answers that contain bracketed words alongside citations

## Testing
- pytest tests/test_conversation_manager.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e5222f314483228d77e869b191afef