### PR TITLE
Consolidate corpus folder controls

### DIFF
--- a/Docs/main_window.html
+++ b/Docs/main_window.html
@@ -289,7 +289,6 @@
         toolbar<span style="color: #666666">.</span>addWidget(<span style="color: #008000">self</span><span style="color: #666666">.</span>_project_combo)
         toolbar<span style="color: #666666">.</span>addSeparator()
         toolbar<span style="color: #666666">.</span>addAction(<span style="color: #008000">self</span><span style="color: #666666">.</span>new_project_action)
-        toolbar<span style="color: #666666">.</span>addAction(<span style="color: #008000">self</span><span style="color: #666666">.</span>add_folder_action)
         toolbar<span style="color: #666666">.</span>addAction(<span style="color: #008000">self</span><span style="color: #666666">.</span>backup_action)
         <span style="color: #008000">self</span><span style="color: #666666">.</span>addToolBar(toolbar)
 </code></pre>
@@ -347,7 +346,9 @@
         controls_header<span style="color: #666666">.</span>addWidget(collapse_left)
         controls_layout<span style="color: #666666">.</span>addLayout(controls_header)
 
-        add_folder_button <span style="color: #666666">=</span> QPushButton(<span style="color: #BA2121">&quot;Index Folder…&quot;</span>, controls_frame)
+        add_folder_button <span style="color: #666666">=</span> QPushButton(
+            <span style="color: #008000">self</span><span style="color: #666666">.</span>add_folder_action<span style="color: #666666">.</span>text(), controls_frame
+        )
         add_folder_button<span style="color: #666666">.</span>setObjectName(<span style="color: #BA2121">&quot;indexFolderButton&quot;</span>)
         add_folder_button<span style="color: #666666">.</span>clicked<span style="color: #666666">.</span>connect(
             <span style="color: #008000; font-weight: bold">lambda</span> _checked<span style="color: #666666">=</span><span style="color: #008000; font-weight: bold">False</span>: <span style="color: #008000">self</span><span style="color: #666666">.</span>add_folder_action<span style="color: #666666">.</span>trigger()

--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -347,7 +347,6 @@ class MainWindow(QMainWindow):
         toolbar.addWidget(self._project_combo)
         toolbar.addSeparator()
         toolbar.addAction(self.new_project_action)
-        toolbar.addAction(self.add_folder_action)
         toolbar.addAction(self.backup_action)
         self.addToolBar(toolbar)
 
@@ -401,7 +400,9 @@ class MainWindow(QMainWindow):
         controls_header.addWidget(collapse_left)
         controls_layout.addLayout(controls_header)
 
-        add_folder_button = QPushButton("Index Folder…", controls_frame)
+        add_folder_button = QPushButton(
+            self.add_folder_action.text(), controls_frame
+        )
         add_folder_button.setObjectName("indexFolderButton")
         add_folder_button.clicked.connect(
             lambda _checked=False: self.add_folder_action.trigger()


### PR DESCRIPTION
## Summary
- update the corpus panel button to use the Add Folder to Corpus action label
- remove the redundant Add Folder to Corpus button from the main toolbar

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e52554b360832297d0e24f8e8b3ee6