### PR TITLE
Fix background chat callbacks not reaching UI

### DIFF
--- a/app/ui/main_window.py
+++ b/app/ui/main_window.py
@@ -11,7 +11,14 @@ from pathlib import Path
 import threading
 from typing import Any, Callable, Iterable
 
-from PyQt6.QtCore import QEasingCurve, QPropertyAnimation, Qt, QTimer, QUrl
+from PyQt6.QtCore import (
+    QEasingCurve,
+    QMetaObject,
+    QPropertyAnimation,
+    Qt,
+    QTimer,
+    QUrl,
+)
 from PyQt6.QtGui import (
     QAction,
     QActionGroup,
@@ -1600,11 +1607,19 @@ class MainWindow(QMainWindow):
                     context_provider=step_context_provider,
                 )
             except LMStudioError as exc:
-                QTimer.singleShot(0, partial(_handle_error, exc))
+                QMetaObject.invokeMethod(
+                    self,
+                    lambda exc=exc: _handle_error(exc),
+                    Qt.ConnectionType.QueuedConnection,
+                )
                 return
 
             answered_at = datetime.now()
-            QTimer.singleShot(0, partial(_handle_success, turn, answered_at))
+            QMetaObject.invokeMethod(
+                self,
+                lambda turn=turn, answered_at=answered_at: _handle_success(turn, answered_at),
+                Qt.ConnectionType.QueuedConnection,
+            )
 
         threading.Thread(target=worker, daemon=True).start()
 


### PR DESCRIPTION
## Summary
- ensure chat worker threads marshal success and error callbacks back to the GUI thread with `QMetaObject.invokeMethod`
- add the necessary Qt import for the queued invocation helper

## Testing
- pytest tests/test_conversation_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68e54b6a68888322a38bc0eca1aa9486