### PR TITLE
Implement task charter and evidence logging in dynamic planning

### DIFF
--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -9,6 +9,7 @@ from .conversation_manager import (
     ConsolidatedSection,
     ConflictNote,
     ConsolidationOutput,
+    EvidenceRecord,
     DynamicPlanningError,
     JudgeReport,
     PlanItem,
@@ -16,8 +17,10 @@ from .conversation_manager import (
     ReasoningVerbosity,
     ResponseMode,
     SelfCheckResult,
+    StateDigestEntry,
     StepContextBatch,
     StepResult,
+    TaskCharter,
 )
 from .conversation_settings import ConversationSettings
 from .document_hierarchy import DocumentHierarchyService
@@ -41,6 +44,7 @@ __all__ = [
     "ConsolidatedSection",
     "ConflictNote",
     "ConsolidationOutput",
+    "EvidenceRecord",
     "DynamicPlanningError",
     "JudgeReport",
     "ExportService",
@@ -49,8 +53,10 @@ __all__ = [
     "ReasoningVerbosity",
     "ResponseMode",
     "SelfCheckResult",
+    "StateDigestEntry",
     "StepContextBatch",
     "StepResult",
+    "TaskCharter",
     "DocumentHierarchyService",
     "LMStudioClient",
     "LMStudioConnectionError",


### PR DESCRIPTION
## Summary
- introduce task charter, state digest, and evidence log data structures and surface them through conversation turns
- update dynamic planning execution to frame tasks, capture retrieval intent, and persist digest and charter metadata into reasoning payloads
- extend reasoning parsers to rebuild charter, digest, and evidence records from stored metadata

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e5c5266b7c83229bc57ac41243d69b