### PR TITLE
Add working memory persistence and retrieval

### DIFF
--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -32,6 +32,7 @@ from .lmstudio_client import (
     LMStudioError,
     LMStudioResponseError,
 )
+from .working_memory import WorkingMemoryService
 
 __all__ = [
     "AnswerLength",
@@ -57,6 +58,7 @@ __all__ = [
     "StepContextBatch",
     "StepResult",
     "TaskCharter",
+    "WorkingMemoryService",
     "DocumentHierarchyService",
     "LMStudioClient",
     "LMStudioConnectionError",

--- a/app/services/project_service.py
+++ b/app/services/project_service.py
@@ -21,6 +21,7 @@ from ..storage import (
     DocumentRepository,
     IngestDocumentRepository,
     ProjectRepository,
+    WorkingMemoryRepository,
 )
 
 
@@ -66,6 +67,7 @@ class ProjectService(QObject):
         self.chats = ChatRepository(self._db)
         self.ingest = IngestDocumentRepository(self._db)
         self.background_tasks = BackgroundTaskLogRepository(self._db)
+        self.working_memory = WorkingMemoryRepository(self._db)
         self._lock = threading.RLock()
         self._active_project_id: int | None = None
         self._ensure_default_project()

--- a/app/services/working_memory.py
+++ b/app/services/working_memory.py
@@ -1,0 +1,267 @@
+"""Service for persisting and retrieving conversational working memory."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, Iterable, Sequence
+
+from ..logging import log_call
+from ..storage import WorkingMemoryRepository
+
+if TYPE_CHECKING:  # pragma: no cover - import cycle guard for type checkers
+    from .conversation_manager import (
+        EvidenceRecord,
+        PlanItem,
+        StateDigestEntry,
+        StepResult,
+    )
+
+
+logger = logging.getLogger(__name__)
+
+
+class WorkingMemoryService:
+    """Coordinate persistence and retrieval of working memory entries."""
+
+    def __init__(self, repository: WorkingMemoryRepository) -> None:
+        self._repository = repository
+
+    @log_call(logger=logger, level=logging.DEBUG, include_args=False)
+    def store_turn_memory(
+        self,
+        *,
+        project_id: int,
+        turn_index: int,
+        question: str,
+        answer: str,
+        plan: Sequence["PlanItem"] | None = None,
+        step_results: Sequence["StepResult"] | None = None,
+        state_digest: Sequence["StateDigestEntry"] | None = None,
+        evidence_log: Sequence["EvidenceRecord"] | None = None,
+    ) -> None:
+        """Persist structured working memory for a completed turn."""
+
+        self._repository.clear_turn(project_id, turn_index)
+        sanitized_question = question.strip()
+        sanitized_answer = answer.strip()
+
+        if sanitized_question:
+            self._repository.add_entry(
+                project_id,
+                turn_index,
+                kind="question",
+                title="Question",
+                summary=sanitized_question,
+                content=f"question {sanitized_question}",
+                metadata={"question": sanitized_question},
+            )
+
+        if sanitized_answer:
+            self._repository.add_entry(
+                project_id,
+                turn_index,
+                kind="final_answer",
+                title="Final Answer",
+                summary=sanitized_answer,
+                content=f"answer {sanitized_answer}",
+                metadata={"question": sanitized_question, "turn_index": turn_index},
+            )
+
+        for index, item in enumerate(plan or [], start=1):
+            description = (item.description or "").strip()
+            status = (item.status or "pending").strip()
+            if not description:
+                continue
+            metadata = {
+                "status": status,
+                "step_index": index,
+                "question": sanitized_question,
+            }
+            content = " ".join(part for part in (description, status, sanitized_question) if part)
+            self._repository.add_entry(
+                project_id,
+                turn_index,
+                step_index=index,
+                kind="plan",
+                title=f"Plan Step {index}",
+                summary=description,
+                content=content,
+                metadata=metadata,
+            )
+
+        for result in step_results or []:
+            summary = (result.answer or "").strip() or (result.description or "").strip()
+            if not summary:
+                continue
+            contexts: list[str] = []
+            for batch in result.contexts:
+                snippets = getattr(batch, "snippets", None)
+                if isinstance(snippets, Iterable):
+                    contexts.extend(str(snippet) for snippet in snippets if snippet)
+            metadata: dict[str, Any] = {
+                "description": result.description,
+                "citation_indexes": list(result.citation_indexes),
+                "insufficient": bool(result.insufficient),
+                "question": sanitized_question,
+                "contexts": contexts,
+            }
+            self._repository.add_entry(
+                project_id,
+                turn_index,
+                step_index=result.index,
+                kind="step_result",
+                title=f"Step Result {result.index}",
+                summary=summary,
+                content=" ".join(part for part in (result.description, summary, sanitized_question) if part),
+                metadata=metadata,
+            )
+
+        for entry in state_digest or []:
+            summary = (entry.summary or "").strip()
+            if not summary:
+                continue
+            metadata = {
+                "citation_indexes": list(entry.citation_indexes),
+                "pending_questions": list(entry.pending_questions),
+                "decisions": list(entry.decisions),
+                "question": sanitized_question,
+                "step_index": entry.step_index,
+            }
+            self._repository.add_entry(
+                project_id,
+                turn_index,
+                step_index=entry.step_index,
+                kind="state_digest",
+                title=f"State Digest {entry.step_index}",
+                summary=summary,
+                content=" ".join(
+                    part
+                    for part in (
+                        summary,
+                        " ".join(entry.pending_questions),
+                        " ".join(entry.decisions),
+                        sanitized_question,
+                    )
+                    if part
+                ),
+                metadata=metadata,
+            )
+
+        for record in evidence_log or []:
+            intent = (record.intent or "").strip()
+            snippets = list(record.snippets)
+            documents = [dict(doc) for doc in record.documents]
+            summary = intent or "Evidence" if snippets else intent
+            metadata = {
+                "intent": intent,
+                "snippets": snippets,
+                "documents": documents,
+                "question": sanitized_question,
+                "step_index": record.step_index,
+            }
+            content = " ".join(part for part in (intent, " ".join(snippets), sanitized_question) if part)
+            self._repository.add_entry(
+                project_id,
+                turn_index,
+                step_index=record.step_index,
+                kind="evidence",
+                title=f"Evidence {record.step_index}",
+                summary=summary.strip() or "Evidence",
+                content=content,
+                metadata=metadata,
+            )
+
+    def collect_context_records(
+        self,
+        query: str,
+        *,
+        project_id: int,
+        limit: int = 5,
+        kinds: Sequence[str] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Return working-memory context records matching ``query``."""
+
+        entries = self._repository.search(project_id, query, limit=limit, kinds=kinds)
+        records: list[dict[str, Any]] = []
+        for entry in entries:
+            metadata = entry.get("metadata") or {}
+            title = self._entry_title(entry)
+            context_text = self._build_context(entry, metadata)
+            records.append(
+                {
+                    "document": {
+                        "id": f"memory-{entry['id']}",
+                        "title": title,
+                        "source_path": self._memory_source_path(project_id, entry),
+                        "metadata": metadata,
+                        "project_id": project_id,
+                        "working_memory": True,
+                        "kind": entry.get("kind"),
+                    },
+                    "chunk": {
+                        "id": entry["id"],
+                        "index": entry.get("step_index") or 0,
+                        "text": entry.get("summary") or title,
+                    },
+                    "context": context_text,
+                    "highlight": entry.get("highlight"),
+                    "score": entry.get("score"),
+                    "memory_entry": entry,
+                }
+            )
+        return records
+
+    @staticmethod
+    def _memory_source_path(project_id: int, entry: dict[str, Any]) -> str:
+        turn_index = entry.get("turn_index") or 0
+        return f"memory://project/{project_id}/turn/{turn_index}/entry/{entry['id']}"
+
+    @staticmethod
+    def _entry_title(entry: dict[str, Any]) -> str:
+        kind = str(entry.get("kind") or "memory").replace("_", " ").title()
+        turn_index = entry.get("turn_index")
+        step_index = entry.get("step_index")
+        if step_index:
+            return f"Turn {turn_index} Step {step_index} {kind}"
+        if turn_index:
+            return f"Turn {turn_index} {kind}"
+        return kind
+
+    @staticmethod
+    def _build_context(entry: dict[str, Any], metadata: dict[str, Any]) -> str:
+        lines: list[str] = []
+        summary = str(entry.get("summary") or "").strip()
+        if summary:
+            lines.append(summary)
+        kind = entry.get("kind")
+        if kind == "plan":
+            status = metadata.get("status")
+            if status:
+                lines.append(f"Status: {status}")
+        elif kind == "step_result":
+            description = metadata.get("description")
+            if description:
+                lines.insert(0, str(description))
+        elif kind == "state_digest":
+            pending = metadata.get("pending_questions") or []
+            if pending:
+                lines.append("Pending questions: " + "; ".join(str(item) for item in pending if item))
+            decisions = metadata.get("decisions") or []
+            if decisions:
+                lines.append("Decisions: " + "; ".join(str(item) for item in decisions if item))
+        elif kind == "evidence":
+            intent = metadata.get("intent")
+            if intent:
+                lines.insert(0, str(intent))
+            snippets = metadata.get("snippets") or []
+            if snippets:
+                lines.append("Snippets: " + " ".join(str(item) for item in snippets if item))
+        elif kind == "final_answer":
+            lines.insert(0, "Final Answer")
+        elif kind == "question":
+            lines.insert(0, "Question")
+        question = metadata.get("question")
+        if question and str(question).strip():
+            lines.append(f"Question: {question}")
+        return "\n".join(line for line in lines if str(line).strip())
+

--- a/app/storage/__init__.py
+++ b/app/storage/__init__.py
@@ -9,6 +9,7 @@ from .database import (
     DocumentRepository,
     IngestDocumentRepository,
     ProjectRepository,
+    WorkingMemoryRepository,
 )
 
 __all__ = [
@@ -20,4 +21,5 @@ __all__ = [
     "DocumentRepository",
     "IngestDocumentRepository",
     "ProjectRepository",
+    "WorkingMemoryRepository",
 ]

--- a/app/storage/schema.sql
+++ b/app/storage/schema.sql
@@ -123,6 +123,33 @@ CREATE TABLE IF NOT EXISTS reasoning_summaries (
     FOREIGN KEY (chat_id) REFERENCES chats(id) ON DELETE CASCADE
 );
 
+CREATE TABLE IF NOT EXISTS working_memory_entries (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    project_id INTEGER NOT NULL,
+    turn_index INTEGER NOT NULL,
+    step_index INTEGER,
+    kind TEXT NOT NULL,
+    title TEXT,
+    summary TEXT,
+    metadata TEXT,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_working_memory_project_turn
+ON working_memory_entries(project_id, turn_index);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS working_memory_index
+USING fts5(
+    content,
+    entry_id UNINDEXED,
+    project_id UNINDEXED,
+    turn_index UNINDEXED,
+    step_index UNINDEXED,
+    kind UNINDEXED,
+    tokenize='porter'
+);
+
 CREATE TABLE IF NOT EXISTS settings (
     key TEXT PRIMARY KEY,
     value TEXT,

--- a/tests/test_ui_main_window.py
+++ b/tests/test_ui_main_window.py
@@ -360,11 +360,11 @@ def test_question_includes_retrieval_context(
     context_path.write_text(context_text, encoding="utf-8")
 
     class RecordingConversationManager:
-        def __init__(self, _client) -> None:
+        def __init__(self, _client, *, working_memory=None, **_kwargs) -> None:
             self.turns: list[ConversationTurn] = []
             self.last_call: dict[str, object] | None = None
             self._state = ConnectionState(True, None)
-
+            
         def add_connection_listener(self, _listener):
             return lambda: None
 

--- a/tests/test_working_memory_service.py
+++ b/tests/test_working_memory_service.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.services.conversation_manager import (
+    EvidenceRecord,
+    PlanItem,
+    StateDigestEntry,
+    StepContextBatch,
+    StepResult,
+)
+from app.services.working_memory import WorkingMemoryService
+from app.storage.database import (
+    DatabaseManager,
+    ProjectRepository,
+    WorkingMemoryRepository,
+)
+
+
+def test_working_memory_service_persists_and_searches(tmp_path) -> None:
+    db_path = Path(tmp_path) / "memory.db"
+    manager = DatabaseManager(db_path)
+    manager.initialize()
+    projects = ProjectRepository(manager)
+    project = projects.create("Test Project")
+    project_id = int(project["id"])
+    repository = WorkingMemoryRepository(manager)
+    service = WorkingMemoryService(repository)
+
+    plan = [PlanItem(description="Collect metrics", status="done")]
+    step_result = StepResult(
+        index=1,
+        description="Collect metrics",
+        answer="Metrics improved over the quarter.",
+        citation_indexes=[1],
+        contexts=[StepContextBatch(snippets=["Metrics snippet"], documents=[])],
+    )
+    digest = [
+        StateDigestEntry(
+            step_index=1,
+            summary="Metrics highlight sustained improvement.",
+            citation_indexes=[1],
+        )
+    ]
+    evidence = [
+        EvidenceRecord(
+            step_index=1,
+            intent="Review quarterly metrics",
+            documents=[{"id": "doc-1", "title": "Metrics Report"}],
+            snippets=["Quarterly metrics show growth"],
+        )
+    ]
+
+    service.store_turn_memory(
+        project_id=project_id,
+        turn_index=1,
+        question="Summarize quarterly metrics performance.",
+        answer="Metrics improved over the quarter.",
+        plan=plan,
+        step_results=[step_result],
+        state_digest=digest,
+        evidence_log=evidence,
+    )
+
+    entries = repository.list_for_project(project_id)
+    kinds = {entry["kind"] for entry in entries}
+    assert {"question", "final_answer", "plan", "step_result", "state_digest", "evidence"}.issubset(kinds)
+
+    results = service.collect_context_records("metrics", project_id=project_id, limit=10)
+    assert results
+    assert any(record["document"].get("working_memory") for record in results)
+
+    manager.close()


### PR DESCRIPTION
## Summary
- add a SQLite-backed working memory repository and service with FTS search
- persist conversation planning artifacts and final answers via the ConversationManager and surface them through the UI context provider
- exercise the new workflow with dedicated unit tests for the service and dynamic planning integration

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e5eab3dff08322a8c691b19650e531