### PR TITLE
Fix conflict citation annotation loop

### DIFF
--- a/app/services/conversation_manager.py
+++ b/app/services/conversation_manager.py
@@ -2310,15 +2310,15 @@ class ConversationManager:
                     if citation_index <= 0 or citation_index > len(aggregated):
                         continue
                     citation = aggregated[citation_index - 1]
-                if isinstance(citation, dict):
-                    citation["conflict_summary"] = note.summary
-                    citation["conflicts"] = [
-                        {
-                            "text": variant["text"],
-                            "citations": variant["citations"],
-                        }
-                        for variant in note.variants
-                    ]
+                    if isinstance(citation, dict):
+                        citation["conflict_summary"] = note.summary
+                        citation["conflicts"] = [
+                            {
+                                "text": variant["text"],
+                                "citations": variant["citations"],
+                            }
+                            for variant in note.variants
+                        ]
         if task_charter is not None:
             reasoning_payload["task_charter"] = asdict(task_charter)
         if finalized_digest_entries:


### PR DESCRIPTION
## Summary
- prevent conflict annotation from referencing an undefined citation when a conflict has no mapped indexes
- ensure each cited record receives conflict metadata instead of only the last entry

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e5f082f8e88322b1643abb28eba1ff