### PR TITLE
Enforce dynamic plan grounding

### DIFF
--- a/tests/test_conversation_manager.py
+++ b/tests/test_conversation_manager.py
@@ -236,8 +236,9 @@ def test_conversation_manager_serializes_threaded_questions(monkeypatch) -> None
                     "snippet": doc_payload.get("snippet", snippet),
                 }
                 time.sleep(0.05)
+                doc_identifier = str(doc_payload.get("id", f"doc-{call_id}"))
                 return ChatMessage(
-                    content=f"Answer {call_id}: {snippet}",
+                    content=f"Answer {call_id}: {snippet} ({doc_identifier})",
                     citations=[citation],
                     reasoning={},
                     raw_response={"call_id": call_id, "preset": preset.value},


### PR DESCRIPTION
## Summary
- mark dynamic plan step answers as insufficient when they omit snippet citations or cite evidence outside the retrieved context
- normalize and compare snippet references from model outputs against retrieved context metadata
- update conversation manager tests and dynamic planning stubs to reflect the stricter grounding requirements

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e671775ac083228bd69ec3bc496907